### PR TITLE
Enable CPU device on SGLang

### DIFF
--- a/python/sglang/srt/configs/device_config.py
+++ b/python/sglang/srt/configs/device_config.py
@@ -10,7 +10,7 @@ class DeviceConfig:
     device: Optional[torch.device]
 
     def __init__(self, device: str = "cuda") -> None:
-        if device in ["cuda", "xpu", "hpu"]:
+        if device in ["cuda", "xpu", "hpu", "cpu"]:
             self.device_type = device
         else:
             raise RuntimeError(f"Not supported device type: {device}")

--- a/python/sglang/srt/layers/fused_moe_patch.py
+++ b/python/sglang/srt/layers/fused_moe_patch.py
@@ -131,3 +131,78 @@ def fused_moe_forward_native(
     x3 = torch.einsum("ti, taoi -> tao", x, w3_weights)
     expert_outs = torch.einsum("tao, taio -> tai", (x1 * x3), w2_weights)
     return torch.einsum("tai,ta -> ti", expert_outs, topk_weights.to(expert_outs.dtype))
+
+def moe_forward_native(
+    layer: torch.nn.Module,
+    x: torch.Tensor,
+    use_grouped_topk: bool,
+    top_k: int,
+    router_logits: torch.Tensor,
+    renormalize: bool,
+    topk_group: Optional[int] = None,
+    num_expert_group: Optional[int] = None,
+    custom_routing_function: Optional[Callable] = None,
+) -> torch.Tensor:
+
+    if use_grouped_topk:
+        assert num_expert_group is not None and topk_group is not None
+        topk_weights, topk_ids = grouped_topk(
+            x,
+            router_logits,
+            top_k,
+            renormalize,
+            num_expert_group,
+            topk_group,
+        )
+    elif custom_routing_function is None:
+        topk_weights, topk_ids = fused_topk_native(x, router_logits, top_k, renormalize)
+    else:
+        topk_weights, topk_ids = custom_routing_function(
+            x, router_logits, top_k, renormalize
+        )
+
+    # Ref code from https://huggingface.co/deepseek-ai/DeepSeek-V2/blob/e0828e3cc0a03408724b80c3cc92c8e072db8d01/modeling_deepseek.py#L589
+    len_experts = layer.num_experts
+    
+    cnts = topk_ids.new_zeros((topk_ids.shape[0], len_experts))
+    cnts.scatter_(1, topk_ids, 1)
+    tokens_per_expert = cnts.sum(dim=0)
+    idxs = topk_ids.view(-1).argsort()
+
+    sorted_tokens = x[idxs // topk_ids.shape[1]]
+    tokens_per_expert = tokens_per_expert.cpu().numpy()
+
+    outputs = []
+    start_idx = 0
+    for i, num_tokens in enumerate(tokens_per_expert):
+        end_idx = start_idx + num_tokens
+        if num_tokens == 0:
+            continue
+        tokens_for_this_expert = sorted_tokens[start_idx:end_idx]
+        
+        layer_w13_weight = layer.w13_weight[i]
+        layer_w2_weight = layer.w2_weight[i]
+        
+        gate_up = F.linear(tokens_for_this_expert, layer_w13_weight)
+        from sglang.srt.layers.activation import SiluAndMul
+        gate_up = SiluAndMul()(gate_up)
+        expert_out = F.linear(gate_up, layer_w2_weight)
+        outputs.append(expert_out)
+        start_idx = end_idx
+
+    outs = (
+        torch.cat(outputs, dim=0)
+        if len(outputs)
+        else sorted_tokens.new_empty(0)
+    )
+    new_x = torch.empty_like(outs)
+
+    new_x[idxs] = outs
+    final_out = (
+        new_x.view(*topk_ids.shape, -1)
+        .type(topk_weights.dtype)
+        .mul_(topk_weights.unsqueeze(dim=-1))
+        .sum(dim=1)
+        .type(new_x.dtype)
+    )
+    return final_out

--- a/python/sglang/srt/layers/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/fused_moe_triton/layer.py
@@ -13,6 +13,7 @@ from vllm.distributed import (
 from vllm.model_executor.custom_op import CustomOp
 
 from sglang.srt.layers.custom_op_util import register_custom_op
+from sglang.srt.layers.fused_moe_patch import moe_forward_native
 from sglang.srt.layers.linear import get_global_server_args_dict
 from sglang.srt.layers.quantization.base_config import (
     QuantizationConfig,
@@ -152,8 +153,29 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
             inplace=True,
         )
 
-    def forward_cpu(self, *args, **kwargs):
-        raise NotImplementedError("The CPU backend currently does not support MoE.")
+    def forward_cpu(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        use_grouped_topk: bool,
+        top_k: int,
+        router_logits: torch.Tensor,
+        renormalize: bool,
+        topk_group: Optional[int] = None,
+        num_expert_group: Optional[int] = None,
+        custom_routing_function: Optional[Callable] = None,
+    ) -> torch.Tensor: 
+        return moe_forward_native(
+            layer,
+            x,
+            use_grouped_topk,
+            top_k,
+            router_logits,
+            renormalize,
+            topk_group,
+            num_expert_group,
+            custom_routing_function,
+        )
 
     def forward_tpu(self, *args, **kwargs) -> torch.Tensor:
         raise NotImplementedError("The TPU backend currently does not support MoE.")

--- a/python/sglang/srt/layers/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/fused_moe_triton/layer.py
@@ -13,6 +13,7 @@ from vllm.distributed import (
 from vllm.model_executor.custom_op import CustomOp
 
 from sglang.srt.layers.custom_op_util import register_custom_op
+from sglang.srt.layers.linear import get_global_server_args_dict
 from sglang.srt.layers.quantization.base_config import (
     QuantizationConfig,
     QuantizeMethodBase,
@@ -204,7 +205,7 @@ class FusedMoE(torch.nn.Module):
             params_dtype = torch.get_default_dtype()
 
         self.tp_size = (
-            tp_size if tp_size is not None else get_tensor_model_parallel_world_size()
+            tp_size if tp_size is not None else get_tensor_model_parallel_world_size(get_global_server_args_dict()["device"])
         )
         self.top_k = top_k
         self.num_experts = num_experts
@@ -406,7 +407,7 @@ class FusedMoE(torch.nn.Module):
         SHARD_ID_TO_SHARDED_DIM = {"w1": 0, "w2": 1, "w3": 0}
 
         expert_data = param.data[expert_id]
-        tp_rank = get_tensor_model_parallel_rank()
+        tp_rank = get_tensor_model_parallel_rank(get_global_server_args_dict()["device"])
 
         # is_transposed: if the dim to shard the weight
         # should be flipped. Required by GPTQ, compressed-tensors

--- a/python/sglang/srt/layers/vocab_parallel_embedding.py
+++ b/python/sglang/srt/layers/vocab_parallel_embedding.py
@@ -19,6 +19,7 @@ from sglang.srt.layers.quantization.base_config import (
     QuantizeMethodBase,
     method_has_implemented_embedding,
 )
+from sglang.srt.managers.schedule_batch import global_server_args_dict
 from sglang.srt.utils import set_weight_attrs
 
 DEFAULT_VOCAB_PADDING_SIZE = 64
@@ -523,6 +524,7 @@ class ParallelLMHead(VocabParallelEmbedding):
             padding_size,
             quant_config,
             prefix,
+            enable_tp=global_server_args_dict["device"]!="cpu",
         )
         self.quant_config = quant_config
         if bias:

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -59,6 +59,7 @@ global_server_args_dict = {
     "enable_nan_detection": ServerArgs.enable_nan_detection,
     "enable_dp_attention": ServerArgs.enable_dp_attention,
     "enable_ep_moe": ServerArgs.enable_ep_moe,
+    "device": ServerArgs.device,
 }
 
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -941,7 +941,8 @@ class Scheduler:
             self.process_batch_result_prefill(batch, result)
         elif batch.forward_mode.is_dummy_first():
             batch.next_batch_sampling_info.update_regex_vocab_mask()
-            self.current_stream.synchronize()
+            if self.device != "cpu":
+                self.current_stream.synchronize()
             batch.next_batch_sampling_info.sampling_info_done.set()
 
     def process_batch_result_prefill(self, batch: ScheduleBatch, result):
@@ -1008,7 +1009,8 @@ class Scheduler:
 
             if batch.next_batch_sampling_info:
                 batch.next_batch_sampling_info.update_regex_vocab_mask()
-                self.current_stream.synchronize()
+                if self.device != "cpu":
+                    self.current_stream.synchronize()
                 batch.next_batch_sampling_info.sampling_info_done.set()
 
         else:  # embedding or reward model
@@ -1087,7 +1089,8 @@ class Scheduler:
 
         if batch.next_batch_sampling_info:
             batch.next_batch_sampling_info.update_regex_vocab_mask()
-            self.current_stream.synchronize()
+            if self.device != "cpu":
+                self.current_stream.synchronize()
             batch.next_batch_sampling_info.sampling_info_done.set()
 
         self.stream_output(batch.reqs, batch.return_logprob)

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -107,11 +107,15 @@ class TpModelWorker:
         ), "Memory pool size is too small"
 
         # Sync random seed across TP workers
-        self.random_seed = broadcast_pyobj(
-            [server_args.random_seed],
-            self.tp_rank,
-            self.model_runner.tp_group.cpu_group,
-        )[0]
+        self.random_seed = (
+            server_args.random_seed 
+            if server_args.device == "cpu" 
+            else broadcast_pyobj(
+                [server_args.random_seed],
+                self.tp_rank,
+                self.model_runner.tp_group.cpu_group,
+            )[0]
+        )
         set_random_seed(self.random_seed)
 
     def get_worker_info(self):
@@ -133,7 +137,7 @@ class TpModelWorker:
         return getattr(self.model_runner.model, "pad_input_ids", None)
 
     def get_tp_cpu_group(self):
-        return self.model_runner.tp_group.cpu_group
+        return None if self.device == "cpu" else self.model_runner.tp_group.cpu_group
 
     def get_memory_pool(self):
         return (

--- a/python/sglang/srt/managers/tp_worker_overlap_thread.py
+++ b/python/sglang/srt/managers/tp_worker_overlap_thread.py
@@ -192,7 +192,8 @@ class TpModelWorkerClient:
         )
 
         # A cuda stream sync here to avoid the cuda illegal memory access error.
-        self.scheduler_stream.synchronize()
+        if self.device != "cpu":
+            self.scheduler_stream.synchronize()
 
         # Push a new batch to the queue
         self.input_queue.put((model_worker_batch, self.future_token_ids_ct))

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -93,8 +93,9 @@ class ModelRunner:
             self.model_config.attention_arch == AttentionArch.MLA
             and not self.server_args.disable_mla
         ):
-            logger.info("MLA optimization is turned on. Use triton backend.")
-            self.server_args.attention_backend = "triton"
+            if self.server_args.device != "cpu":
+                logger.info("MLA optimization is turned on. Use triton backend.")
+                self.server_args.attention_backend = "triton"
 
         if self.server_args.enable_double_sparsity:
             logger.info(
@@ -145,6 +146,7 @@ class ModelRunner:
                 "enable_nan_detection": server_args.enable_nan_detection,
                 "enable_dp_attention": server_args.enable_dp_attention,
                 "enable_ep_moe": server_args.enable_ep_moe,
+                "device": server_args.device,
             }
         )
 
@@ -205,18 +207,19 @@ class ModelRunner:
         else:
             dist_init_method = f"tcp://127.0.0.1:{self.dist_port}"
         set_custom_all_reduce(not self.server_args.disable_custom_all_reduce)
-        init_distributed_environment(
-            backend=backend,
-            world_size=self.tp_size,
-            rank=self.tp_rank,
-            local_rank=self.gpu_id,
-            distributed_init_method=dist_init_method,
-        )
-        initialize_model_parallel(tensor_model_parallel_size=self.tp_size)
+        if self.device != "cpu":
+            init_distributed_environment(
+                backend=backend,
+                world_size=self.tp_size,
+                rank=self.tp_rank,
+                local_rank=self.gpu_id,
+                distributed_init_method=dist_init_method,
+            )
+            initialize_model_parallel(tensor_model_parallel_size=self.tp_size)
         min_per_gpu_memory = get_available_gpu_memory(
             self.device, self.gpu_id, distributed=self.tp_size > 1
         )
-        self.tp_group = get_tp_group()
+        self.tp_group = get_tp_group(self.device)
 
         # Check memory for tensor parallelism
         if self.tp_size > 1:

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -237,7 +237,8 @@ class ModelRunner:
         )
 
         # This can reduce thread conflicts and speed up weight loading.
-        torch.set_num_threads(1)
+        if self.device != "cpu":
+            torch.set_num_threads(1)
         if self.device == "cuda":
             if torch.cuda.get_device_capability()[0] < 8:
                 logger.info(

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -98,7 +98,7 @@ class DeepseekV2MoE(nn.Module):
         quant_config: Optional[QuantizationConfig] = None,
     ):
         super().__init__()
-        self.tp_size = get_tensor_model_parallel_world_size()
+        self.tp_size = get_tensor_model_parallel_world_size(global_server_args_dict["device"])
         self.routed_scaling_factor = config.routed_scaling_factor
         self.n_shared_experts = config.n_shared_experts
         self.routed_scaling_factor = config.routed_scaling_factor
@@ -204,7 +204,7 @@ class DeepseekV2Attention(nn.Module):
         self.q_lora_rank = q_lora_rank
         self.kv_lora_rank = kv_lora_rank
         self.num_heads = num_heads
-        tp_size = get_tensor_model_parallel_world_size()
+        tp_size = get_tensor_model_parallel_world_size(global_server_args_dict["device"])
         assert num_heads % tp_size == 0
         self.num_local_heads = num_heads // tp_size
         self.scaling = self.qk_head_dim**-0.5
@@ -261,6 +261,7 @@ class DeepseekV2Attention(nn.Module):
             base=rope_theta,
             rope_scaling=rope_scaling,
             is_neox_style=False,
+            device=global_server_args_dict["device"],
         )
 
         if rope_scaling:
@@ -352,7 +353,7 @@ class DeepseekV2AttentionMLA(nn.Module):
         self.q_lora_rank = q_lora_rank
         self.kv_lora_rank = kv_lora_rank
         self.num_heads = num_heads
-        tp_size = get_tensor_model_parallel_world_size()
+        tp_size = get_tensor_model_parallel_world_size(global_server_args_dict["device"])
         assert num_heads % tp_size == 0
         self.num_local_heads = num_heads if use_dp else num_heads // tp_size
         self.scaling = self.qk_head_dim**-0.5
@@ -757,7 +758,7 @@ class DeepseekV2Model(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
-            enable_tp=not global_server_args_dict["enable_dp_attention"],
+            enable_tp=not global_server_args_dict["enable_dp_attention"] and global_server_args_dict["device"] != "cpu",
         )
         self.layers = nn.ModuleList(
             [
@@ -811,7 +812,7 @@ class DeepseekV2ForCausalLM(nn.Module):
             self.lm_head = ParallelLMHead(
                 config.vocab_size, config.hidden_size, quant_config=quant_config
             )
-            self.logits_processor = LogitsProcessor(config)
+            self.logits_processor = LogitsProcessor(config, skip_all_gather=global_server_args_dict["device"]=="cpu")
 
     @torch.no_grad()
     def forward(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -356,7 +356,7 @@ class ServerArgs:
             "--device",
             type=str,
             default="cuda",
-            choices=["cuda", "xpu", "hpu"],
+            choices=["cuda", "xpu", "hpu", "cpu"],
             help="The device type.",
         )
         parser.add_argument(

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -20,6 +20,7 @@ import json
 import logging
 import os
 import pickle
+import psutil
 import random
 import re
 import resource
@@ -215,6 +216,10 @@ def get_available_gpu_memory(device, gpu_id, distributed=False, empty_cache=True
             )
 
         free_gpu_memory, total_gpu_memory = torch.hpu.mem_get_info()
+
+    elif device == "cpu":
+        # TODO: rename the variables in the current function to be not GPU specific
+        free_gpu_memory = psutil.virtual_memory().available
 
     if distributed:
         tensor = torch.tensor(free_gpu_memory, dtype=torch.float32).to(


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This PR enables CPU device on SGLang.
We need to modify several functions in `vllm` as well to make it work. The vllm branch to use is: https://github.com/chunyuan-w/vllm/tree/chunyuan/enable_cpu_device

## Modifications

- Add `"cpu"` device into the server args.
- For TP related functions, add `device` as an optional input (which we will read in vllm: https://github.com/chunyuan-w/vllm/commit/efda69bc2c1e4a16d8f7b6fbfc7943d541645c4d)
- Add a function to calculate free memory for CPU. This is needed to calculate the size of the KV cache memory pool.
- Add a native implementation for MoE following the original implementation in the model: [moe_infer in deepseek](https://huggingface.co/deepseek-ai/DeepSeek-V2/blob/e0828e3cc0a03408724b80c3cc92c8e072db8d01/modeling_deepseek.py#L589).


<!-- Describe the changes made in this PR. -->

## Example
We only support ` --disable-mla` for now.

### Bench one batch
Below is an example command line to run `DeepSeek-Coder-V2-Lite-Instruct`:
```sh
numactl --physcpubind=0-39 --membind=0 python3 -m sglang.bench_one_batch --batch-size 1 --input 1024 --output 8 --model deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct --trust-remote-code --device cpu --attention-backend torch_native --disable-mla
```

### Server mode
Command line on server side:
```sh
numactl --physcpubind=0-39 --membind=0 python3 -m sglang.launch_server --model deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct --disable-radix --trust-remote-code --device cpu --attention-backend torch_native --disable-mla --log-requests
```

Command line on client side:
```sh
# Bench the serving
python3 -m sglang.bench_serving --backend sglang --num-prompts 5

# Example for collecting the score on mmlu for accuracy
python3 -m sglang.test.run_eval --eval-name mmlu --num-examples 64 --port 30000
```

### Examples of generated sentences:
```
Input 1:
'could you write me a fic in which connor rhodes from chicago med plays a parental role to the reader?'
Output 1:
'\nI\'d love to write a fanfic where Connor Rhodes from Chicago Med plays a parental role to the reader. This would be a romantic, angsty, and emotional story where Connor would become a father figure to the reader, and they would develop a deep connection. Here\'s a rough outline of how the story could go:\n\nTitle: "Parenthood by Chance"\n\nChapter 1: The Unexpected Meeting\nThe reader, a young woman in her early 30s, is going through a difficult time in her life. She\'s recently lost her job, her relationship has ended, and she\'s struggling to care for her ailing mother. One day, while walking her dog, she witnesses a medical emergency involving Connor Rhodes, a doctor at the fictional Chicago hospital where the show is set. Connor saves the day, and the reader is impressed by his skills and compassion.\n\nChapter 2: The Unexpected Help\nThe reader, feeling grateful for Connor\'s intervention, decides to write a thank-you note. She visits the hospital and, after some hesitation, hands over the note to Connor. He reads it and is touched by her words, and they strike up a conversation. The reader is surprised to learn that Connor is a single father raising his teenage daughter, Emma.\n\nChapter 3: A New Friendship\nConnor invites the reader to join him and Emma for dinner one evening. They hit it off, and the reader finds herself drawn to Connor and Emma. Over the next few months, the reader and Connor grow closer, and she starts to feel like a part of their family. Connor, in turn, sees a kindred spirit in the reader, someone who understands his dedication to his family and his work.\n\nChapter 4: The Unlikely Proposal\nAs the reader and Connor spend more time together, they begin to realize'

Input 2:
'Why do people in rust type ` println!("Hello, {}!", name);` instead of ` println!("Hello, {name}!");`?'
Output 2:
'\n\nThe `println!` macro in Rust is a powerful tool for printing formatted strings to the console. It uses a syntax that is similar to C\'s `printf` function, but with some additional features.\n\nThe syntax `println!("Hello, {}!", name);` is preferred over `println!("Hello, {name}!");` for several reasons:\n\n1. **Readability**: The first syntax is more readable and easier to understand. It clearly separates the format string from the arguments, making it easier to read and maintain.\n\n2. **Flexibility**: The first syntax allows for more flexibility in formatting. You can include multiple arguments and specify their positions in the format string, which is not possible with the second syntax.\n\n3. **Error-proneness**: The first syntax is less error-prone. If you accidentally misspell a placeholder name in the second syntax, the Rust compiler won\'t be able to catch the error, whereas it will with the first syntax.\n\nHere\'s an example to illustrate the difference:\n\n```rust\nfn main() {\n    let name = "Alice";\n    println!("Hello, {}!", name); // Preferred syntax\n    println!("Hello, {name}!"); // Less preferred syntax\n}\n```\n\nIn the first example, `'
```





