### PR TITLE
bind OpenMP threads to CPU cores

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -16,6 +16,7 @@
 import gc
 import json
 import logging
+import os
 import time
 from typing import List, Optional, Tuple
 
@@ -172,6 +173,13 @@ class ModelRunner:
 
         set_cpu_offload_max_bytes(int(server_args.cpu_offload_gb * 1024**3))
 
+        # Init OpenMP threads binding
+        omp_cpuids = os.environ.get("SGLANG_CPU_OMP_THREADS_BIND", "all")
+        if omp_cpuids == "all":
+            self.local_omp_cpuid = "all"
+        else:
+            self.local_omp_cpuid = omp_cpuids.split("|")[tp_rank]
+
         # Get memory before model loading
         min_per_gpu_memory = self.init_torch_distributed()
 
@@ -236,6 +244,10 @@ class ModelRunner:
         set_custom_all_reduce(not self.server_args.disable_custom_all_reduce)
 
         if not self.is_draft_worker:
+            # Bind OpenMP threads to CPU cores
+            if self.device == "cpu" and self.local_omp_cpuid != "all":
+                torch.ops._C_utils.init_cpu_threads_env(self.local_omp_cpuid)
+
             # Only initilzie the distributed environment on the target model worker.
             init_distributed_environment(
                 backend=backend,


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Add a environment variable `SGLANG_CPU_OMP_THREADS_BIND` to bind OpenMP threads to CPU cores following the practice in vllm: [VLLM_CPU_OMP_THREADS_BIND](https://docs.vllm.ai/en/latest/getting_started/installation/cpu/index.html#related-runtime-environment-variables).

The usage is the same as that in vllm:
- `SGLANG_CPU_OMP_THREADS_BIND=0-31` means there will be 32 OpenMP threads bound on 0-31 CPU cores. 
- `SGLANG_CPU_OMP_THREADS_BIND=0-31|32-63` means there will be 2 tensor parallel processes, 32 OpenMP threads of rank0 are bound on 0-31 CPU cores, and the OpenMP threads of rank1 are bound on 32-63 CPU cores.


<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
