### PR TITLE
Optimize `all_reduce` by porting the shared memory kernel of deepspeed

### DIFF
--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -13,7 +13,6 @@ from vllm.distributed import (
     get_tensor_model_parallel_world_size,
     split_tensor_along_last_dim,
     tensor_model_parallel_all_gather,
-    tensor_model_parallel_all_reduce,
 )
 
 from sglang.srt.layers.parameter import (
@@ -28,7 +27,7 @@ from sglang.srt.layers.quantization.base_config import (
     QuantizeMethodBase,
 )
 from sglang.srt.layers.quantization.fp8_utils import BlockQuantScaleParameter
-from sglang.srt.utils import set_weight_attrs
+from sglang.srt.utils import set_weight_attrs, tensor_model_parallel_all_reduce_wrapper
 
 logger = logging.getLogger(__name__)
 
@@ -1239,7 +1238,7 @@ class RowParallelLinear(LinearBase):
         bias_ = None if (self.tp_rank > 0 or self.skip_bias_add) else self.bias
         output_parallel = self.quant_method.apply(self, input_parallel, bias=bias_)
         if self.reduce_results and self.tp_size > 1:
-            output = tensor_model_parallel_all_reduce(output_parallel)
+            output = tensor_model_parallel_all_reduce_wrapper(output_parallel)
         else:
             output = output_parallel
 

--- a/python/sglang/srt/layers/vocab_parallel_embedding.py
+++ b/python/sglang/srt/layers/vocab_parallel_embedding.py
@@ -10,7 +10,6 @@ from vllm.distributed import (
     divide,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
-    tensor_model_parallel_all_reduce,
 )
 
 from sglang.srt.layers.parameter import BasevLLMParameter
@@ -19,7 +18,7 @@ from sglang.srt.layers.quantization.base_config import (
     QuantizeMethodBase,
     method_has_implemented_embedding,
 )
-from sglang.srt.utils import set_weight_attrs
+from sglang.srt.utils import set_weight_attrs, tensor_model_parallel_all_reduce_wrapper
 
 DEFAULT_VOCAB_PADDING_SIZE = 64
 
@@ -484,7 +483,7 @@ class VocabParallelEmbedding(torch.nn.Module):
         if self.tp_size > 1:
             output_parallel.masked_fill_(input_mask.unsqueeze(-1), 0)
             # Reduce across all the model parallel GPUs.
-            output = tensor_model_parallel_all_reduce(output_parallel)
+            output = tensor_model_parallel_all_reduce_wrapper(output_parallel)
         else:
             output = output_parallel
         return output

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -27,7 +27,6 @@ from vllm.distributed import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
     get_tp_group,
-    tensor_model_parallel_all_reduce,
 )
 from vllm.model_executor.layers.rotary_embedding import get_rope
 
@@ -57,7 +56,11 @@ from sglang.srt.layers.vocab_parallel_embedding import (
 from sglang.srt.managers.schedule_batch import global_server_args_dict
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
-from sglang.srt.utils import is_flashinfer_available, is_hip
+from sglang.srt.utils import (
+    is_flashinfer_available,
+    is_hip,
+    tensor_model_parallel_all_reduce_wrapper,
+)
 
 is_hip_ = is_hip()
 
@@ -181,7 +184,9 @@ class DeepseekV2MoE(nn.Module):
         if shared_output is not None:
             final_hidden_states = final_hidden_states + shared_output
         if self.tp_size > 1:
-            final_hidden_states = tensor_model_parallel_all_reduce(final_hidden_states)
+            final_hidden_states = tensor_model_parallel_all_reduce_wrapper(
+                final_hidden_states
+            )
 
         return final_hidden_states.view(num_tokens, hidden_dim)
 

--- a/sgl-kernel/setup.py
+++ b/sgl-kernel/setup.py
@@ -1,9 +1,15 @@
+import os
 from pathlib import Path
 
+import torch
 from setuptools import setup
-from torch.utils.cpp_extension import BuildExtension, CUDAExtension
+from torch.utils.cpp_extension import BuildExtension, CppExtension, CUDAExtension
 
 root = Path(__file__).parent.resolve()
+
+force_cuda = os.environ.get("SGL_KERNEL_FORCE_CUDA", "0") == "1"
+
+build_cuda_sources = torch.cuda.is_available() or force_cuda
 
 
 def get_version():
@@ -24,7 +30,8 @@ def update_wheel_platform_tag():
 
 
 cutlass = root / "3rdparty" / "cutlass"
-include_dirs = [
+include_dirs = []
+cuda_include_dirs = [
     cutlass.resolve() / "include",
     cutlass.resolve() / "tools" / "util" / "include",
     root / "src" / "sgl-kernel" / "csrc",
@@ -41,24 +48,38 @@ nvcc_flags = [
     "-U__CUDA_NO_HALF2_OPERATORS__",
 ]
 cxx_flags = ["-O3"]
-libraries = ["c10", "torch", "torch_python", "cuda"]
+extra_compile_args = {"cxx": cxx_flags}
+libraries = ["c10", "torch", "torch_python"]
+sources = [
+    "src/sgl-kernel/csrc/cpu/interface.cpp",
+    "src/sgl-kernel/csrc/cpu/shm.cpp",
+]
+cuda_sources = (
+    [
+        "src/sgl-kernel/csrc/trt_reduce_internal.cu",
+        "src/sgl-kernel/csrc/trt_reduce_kernel.cu",
+        "src/sgl-kernel/csrc/moe_align_kernel.cu",
+        "src/sgl-kernel/csrc/int8_gemm_kernel.cu",
+        "src/sgl-kernel/csrc/sampling_scaling_penalties.cu",
+        "src/sgl-kernel/csrc/sgl_kernel_ops.cu",
+    ],
+)
+if build_cuda_sources:
+    sources.update(cuda_sources)
+    include_dirs.extend(cuda_include_dirs)
+    extra_compile_args.update({"nvcc": nvcc_flags})
+    libraries.append("cuda")
+    Extension = CUDAExtension
+else:
+    Extension = CppExtension
+
 extra_link_args = ["-Wl,-rpath,$ORIGIN/../../torch/lib", "-L/usr/lib/x86_64-linux-gnu"]
 ext_modules = [
-    CUDAExtension(
+    Extension(
         name="sgl_kernel.ops._kernels",
-        sources=[
-            "src/sgl-kernel/csrc/trt_reduce_internal.cu",
-            "src/sgl-kernel/csrc/trt_reduce_kernel.cu",
-            "src/sgl-kernel/csrc/moe_align_kernel.cu",
-            "src/sgl-kernel/csrc/int8_gemm_kernel.cu",
-            "src/sgl-kernel/csrc/sampling_scaling_penalties.cu",
-            "src/sgl-kernel/csrc/sgl_kernel_ops.cu",
-        ],
+        sources=sources,
         include_dirs=include_dirs,
-        extra_compile_args={
-            "nvcc": nvcc_flags,
-            "cxx": cxx_flags,
-        },
+        extra_compile_args=extra_compile_args,
         libraries=libraries,
         extra_link_args=extra_link_args,
     ),

--- a/sgl-kernel/src/sgl-kernel/csrc/cpu/interface.cpp
+++ b/sgl-kernel/src/sgl-kernel/csrc/cpu/interface.cpp
@@ -6,13 +6,14 @@
 static int world_rank = -1;
 static int world_size = -1;
 
-static bool is_initialized = 0;
+static bool is_initialized = false;
 
 static bool all_ranks_local_p = false;
 
 void initialize(int size, int rank) {
-  if (is_initialized)
+  if (is_initialized) {
     return;
+  }
 
   // Check whether all ranks is on the same physical machine.
   // If true, we will use an SHM based low latency allreduce
@@ -29,7 +30,7 @@ void initialize(int size, int rank) {
 
   world_size = size;
   world_rank = rank;
-  is_initialized = 1;
+  is_initialized = true;
 
   auto addr_string = std::getenv("MASTER_ADDR");
   if (addr_string == NULL) {

--- a/sgl-kernel/src/sgl-kernel/csrc/cpu/interface.cpp
+++ b/sgl-kernel/src/sgl-kernel/csrc/cpu/interface.cpp
@@ -10,60 +10,81 @@ static bool is_initialized = 0;
 
 static bool all_ranks_local_p = false;
 
-void initialize(int size, int rank)
-{
-    if (is_initialized) return;
-
-    // Check whether all ranks is on the same physical machine.
-    // If true, we will use an SHM based low latency allreduce
-
-    auto ls_string = std::getenv("LOCAL_SIZE");
-    int ls = 0;
-    if (ls_string != NULL) { ls = std::stoi(std::getenv("LOCAL_SIZE")); }
-
-    if (size >= 1 && size == ls) { all_ranks_local_p = true; }
-
-    world_size = size;
-    world_rank = rank;
-    is_initialized = 1;
-
-    auto addr_string = std::getenv("MASTER_ADDR");
-    if (addr_string == NULL) { addr_string = ""; }
-    auto port_string = std::getenv("MASTER_PORT");
-    if (port_string == NULL) { port_string = ""; }
-
-    if (all_ranks_local_p) { shm_initialize(size, rank, addr_string, port_string); }
-}
-
-void shm_allreduce(torch::Tensor& data, c10::intrusive_ptr<c10d::ProcessGroup> process_group, py::object op) {
-    static py::object ReduceOp = py::module_::import("torch.distributed").attr("ReduceOp");
-    static auto ReduceOpSum = (int)py::int_(ReduceOp.attr("SUM").attr("value"));
-    TORCH_CHECK(py::int_(op.attr("value")) == ReduceOpSum, "Only torch.distributed.ReduceOp.SUM is supported");
-
-    auto numel = data.numel();
-
-    int data_size = 0;
-    bool data_type_fallback = false;
-
-    switch (data.scalar_type()) {
-        case c10::ScalarType::BFloat16: data_size = numel * 2; break;
-        case c10::ScalarType::Float: data_size = numel * 4; break;
-        default: data_type_fallback = true;
-    }
-
-    if (data_type_fallback || !all_ranks_local_p) {
-        // Fallback to torch distributed allreduce
-        std::vector<torch::Tensor> tensors = {data};
-        process_group->allreduce(tensors)->wait();
-    } else {
-        all_reduce_outer_loop(data, numel, data_size);
-    }
-
+void initialize(int size, int rank) {
+  if (is_initialized)
     return;
+
+  // Check whether all ranks is on the same physical machine.
+  // If true, we will use an SHM based low latency allreduce
+
+  auto ls_string = std::getenv("LOCAL_SIZE");
+  int ls = 0;
+  if (ls_string != NULL) {
+    ls = std::stoi(std::getenv("LOCAL_SIZE"));
+  }
+
+  if (size >= 1 && size == ls) {
+    all_ranks_local_p = true;
+  }
+
+  world_size = size;
+  world_rank = rank;
+  is_initialized = 1;
+
+  auto addr_string = std::getenv("MASTER_ADDR");
+  if (addr_string == NULL) {
+    addr_string = "";
+  }
+  auto port_string = std::getenv("MASTER_PORT");
+  if (port_string == NULL) {
+    port_string = "";
+  }
+
+  if (all_ranks_local_p) {
+    shm_initialize(size, rank, addr_string, port_string);
+  }
 }
 
-PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
-{
-    m.def("initialize", &initialize, "shm initialize");
-    m.def("shm_allreduce", &shm_allreduce, "low latency all_reduce implementation");
+void shm_allreduce(
+    torch::Tensor& data,
+    c10::intrusive_ptr<c10d::ProcessGroup> process_group,
+    py::object op) {
+  static py::object ReduceOp =
+      py::module_::import("torch.distributed").attr("ReduceOp");
+  static auto ReduceOpSum = (int)py::int_(ReduceOp.attr("SUM").attr("value"));
+  TORCH_CHECK(
+      py::int_(op.attr("value")) == ReduceOpSum,
+      "Only torch.distributed.ReduceOp.SUM is supported");
+
+  auto numel = data.numel();
+
+  int data_size = 0;
+  bool data_type_fallback = false;
+
+  switch (data.scalar_type()) {
+    case c10::ScalarType::BFloat16:
+      data_size = numel * 2;
+      break;
+    case c10::ScalarType::Float:
+      data_size = numel * 4;
+      break;
+    default:
+      data_type_fallback = true;
+  }
+
+  if (data_type_fallback || !all_ranks_local_p) {
+    // Fallback to torch distributed allreduce
+    std::vector<torch::Tensor> tensors = {data};
+    process_group->allreduce(tensors)->wait();
+  } else {
+    all_reduce_outer_loop(data, numel, data_size);
+  }
+
+  return;
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("initialize", &initialize, "shm initialize");
+  m.def(
+      "shm_allreduce", &shm_allreduce, "low latency all_reduce implementation");
 }

--- a/sgl-kernel/src/sgl-kernel/csrc/cpu/interface.cpp
+++ b/sgl-kernel/src/sgl-kernel/csrc/cpu/interface.cpp
@@ -1,0 +1,69 @@
+#include <torch/extension.h>
+
+#include "shm.h"
+
+// Communication settings
+static int world_rank = -1;
+static int world_size = -1;
+
+static bool is_initialized = 0;
+
+static bool all_ranks_local_p = false;
+
+void initialize(int size, int rank)
+{
+    if (is_initialized) return;
+
+    // Check whether all ranks is on the same physical machine.
+    // If true, we will use an SHM based low latency allreduce
+
+    auto ls_string = std::getenv("LOCAL_SIZE");
+    int ls = 0;
+    if (ls_string != NULL) { ls = std::stoi(std::getenv("LOCAL_SIZE")); }
+
+    if (size >= 1 && size == ls) { all_ranks_local_p = true; }
+
+    world_size = size;
+    world_rank = rank;
+    is_initialized = 1;
+
+    auto addr_string = std::getenv("MASTER_ADDR");
+    if (addr_string == NULL) { addr_string = ""; }
+    auto port_string = std::getenv("MASTER_PORT");
+    if (port_string == NULL) { port_string = ""; }
+
+    if (all_ranks_local_p) { shm_initialize(size, rank, addr_string, port_string); }
+}
+
+void shm_allreduce(torch::Tensor& data, c10::intrusive_ptr<c10d::ProcessGroup> process_group, py::object op) {
+    static py::object ReduceOp = py::module_::import("torch.distributed").attr("ReduceOp");
+    static auto ReduceOpSum = (int)py::int_(ReduceOp.attr("SUM").attr("value"));
+    TORCH_CHECK(py::int_(op.attr("value")) == ReduceOpSum, "Only torch.distributed.ReduceOp.SUM is supported");
+
+    auto numel = data.numel();
+
+    int data_size = 0;
+    bool data_type_fallback = false;
+
+    switch (data.scalar_type()) {
+        case c10::ScalarType::BFloat16: data_size = numel * 2; break;
+        case c10::ScalarType::Float: data_size = numel * 4; break;
+        default: data_type_fallback = true;
+    }
+
+    if (data_type_fallback || !all_ranks_local_p) {
+        // Fallback to torch distributed allreduce
+        std::vector<torch::Tensor> tensors = {data};
+        process_group->allreduce(tensors)->wait();
+    } else {
+        all_reduce_outer_loop(data, numel, data_size);
+    }
+
+    return;
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
+{
+    m.def("initialize", &initialize, "shm initialize");
+    m.def("shm_allreduce", &shm_allreduce, "low latency all_reduce implementation");
+}

--- a/sgl-kernel/src/sgl-kernel/csrc/cpu/shm.cpp
+++ b/sgl-kernel/src/sgl-kernel/csrc/cpu/shm.cpp
@@ -1,0 +1,564 @@
+#include <ATen/ATen.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <immintrin.h>
+
+#include "shm.h"
+
+// states for collectives
+enum coll_state {
+    coll_begin = 0,
+    coll_allreduce_naive__copy_in_done,
+    coll_allreduce_naive__reduce_done,
+    // alternative state when allreduce is working on alternative buffer
+    // of the double buffer.
+    coll_alt1_allreduce_naive__copy_in_done,
+    coll_alt2_allreduce_naive__copy_in_done,
+    coll_alt1_allreduce_naive__reduce_done,
+};
+
+// SHM building blocks
+struct SharedData {
+    const char* name;
+    int descriptor;
+    void* bytes;
+    size_t nbytes;
+};
+
+void shared_open(SharedData* data, const char* name, size_t nbytes)
+{
+    int d = shm_open(name, O_RDWR, S_IRUSR | S_IWUSR);
+    if (d != -1) {
+        void* bytes = mmap(NULL, nbytes, PROT_READ | PROT_WRITE, MAP_SHARED, d, 0);
+        data->name = name;
+        data->descriptor = d;
+        data->bytes = bytes;
+        data->nbytes = nbytes;
+    } else {
+        if (errno != ENOENT) {
+            // don't print if shm can not be found because we want to loop over from
+            // caller again until the other ranks created the shm
+            printf("shared_open %s failed, errno=%d\n", name, errno);
+        }
+        data->descriptor = -1;
+    }
+}
+
+
+void shared_create(SharedData* data, const char* name, void* bytes, size_t nbytes)
+{
+    int d = shm_open(name, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    if (d != -1) {
+        if (nbytes = write(d, bytes, nbytes)) { shared_open(data, name, nbytes); }
+    } else {
+        printf("shared_create %s failed\n", name);
+    }
+}
+
+static int world_size;
+
+// SHM based allreduce helper functions
+// buffer that holds shm name
+#define NAME_BUF_SIZE 1000
+#define MAX_BUF_SIZE 1048576 * 32
+#define NAIVE_ALLREDUCE_THRESHOLD 1048576
+#define SHM_BUFFER_NAME "deepspeed_allreduce_buffer"
+struct allreduce_workspace {
+    enum coll_state states[2];  // idx=0 -- state for symmetric_naive_all_reduce
+                                // idx=1 -- state for distributed_naive_all_reduce
+    // double buffer to avoid syncing between rounds
+    // offset=0 -- 2*NAIVE_ALLREDUCE_THRESHOLD : buffer for symmetric_naive_all_reduce
+    // after that : buffer for distributed_naive_all_reduce
+    char buffer[2 * NAIVE_ALLREDUCE_THRESHOLD + 2 * MAX_BUF_SIZE];
+};
+
+#define BUFFER0_OFFSET(current_buffer) current_buffer* NAIVE_ALLREDUCE_THRESHOLD
+#define BUFFER1_OFFSET(current_buffer) 2 * NAIVE_ALLREDUCE_THRESHOLD + current_buffer* MAX_BUF_SIZE
+
+struct allreduce_workspace** workspace;
+
+// buffer for small messages, double buffer
+char** symmetric_buffer[2];
+// buffer for large messages, double buffer
+char** distributed_buffer[2];
+
+void wait_buffer_state_until_2(int index,
+                               enum coll_state state0,
+                               enum coll_state state1,
+                               int state_group)
+{
+    volatile enum coll_state* state_ptr = &(workspace[index]->states[state_group]);
+
+    while (1) {
+        volatile enum coll_state cur_state = *state_ptr;
+        if (cur_state == state0 || cur_state == state1) break;
+    }
+}
+
+__m512 cvt_bf16_to_fp32(const __m256i src) __attribute__((target("avx512bw")));
+inline __m512 cvt_bf16_to_fp32(const __m256i src)
+{
+    auto y = _mm512_cvtepu16_epi32(src);
+    return _mm512_castsi512_ps(_mm512_bslli_epi128(y, 2));
+}
+
+inline __m256i cvt_fp32_to_bf16(const __m512 src) __attribute__((target("avx512bw")));
+inline __m256i cvt_fp32_to_bf16(const __m512 src)
+{
+    __m512i value = _mm512_castps_si512(src);
+    __m512i nan = _mm512_set1_epi32(0xffff);
+    auto mask_value = _mm512_cmp_ps_mask(src, src, _CMP_ORD_Q);
+    __m512i ones = _mm512_set1_epi32(0x1);
+    __m512i vec_bias = _mm512_set1_epi32(0x7fff);
+    // uint32_t lsb = (input >> 16) & 1;
+    auto t_value = _mm512_and_si512(_mm512_srli_epi32(value, 16), ones);
+    // uint32_t rounding_bias = 0x7fff + lsb;
+    t_value = _mm512_add_epi32(t_value, vec_bias);
+    // input += rounding_bias;
+    t_value = _mm512_add_epi32(t_value, value);
+    // input = input >> 16;
+    t_value = _mm512_srli_epi32(t_value, 16);
+    // Check NaN before converting back to bf16
+    t_value = _mm512_mask_blend_epi32(mask_value, nan, t_value);
+    return _mm512_cvtusepi32_epi16(t_value);
+}
+
+__m512 cvt_fp16_to_fp32(const __m256i src) __attribute__((target("avx512bw")));
+inline __m512 cvt_fp16_to_fp32(const __m256i src) { return _mm512_cvtph_ps(src); }
+
+inline __m256i cvt_fp32_to_fp16(const __m512 src) __attribute__((target("avx512bw")));
+inline __m256i cvt_fp32_to_fp16(const __m512 src)
+{
+    return _mm512_cvtps_ph(src, (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC));
+}
+
+void reduce_bf16_buffers(int start_elements, int num_elements, char* to_buffer, char** buffers)
+    __attribute__((target("avx512bw")));
+
+void reduce_fp16_buffers(int start_elements, int num_elements, char* to_buffer, char** buffers)
+    __attribute__((target("avx512bw")));
+
+void reduce_fp32_buffers(int start_elements, int num_elements, char* to_buffer, char** buffers)
+    __attribute__((target("avx512bw")));
+
+void reduce_all_buffers(int start_elements,
+                        int num_elements,
+                        c10::ScalarType scalar_type,
+                        int to_buffer_idx,
+                        char* to_buffer,
+                        char** buffers)
+{
+    switch (scalar_type) {
+        case c10::ScalarType::BFloat16:
+            reduce_bf16_buffers(start_elements, num_elements, to_buffer, buffers);
+            break;
+        case c10::ScalarType::Half:
+            reduce_fp16_buffers(start_elements, num_elements, to_buffer, buffers);
+            break;
+        case c10::ScalarType::Float:
+            reduce_fp32_buffers(start_elements, num_elements, to_buffer, buffers);
+            break;
+        default: assert(!"Should not get here");
+    }
+}
+
+#define CVT_ADD_BF16(x)                                                                      \
+    do {                                                                                     \
+        auto in##x##_val = cvt_bf16_to_fp32(_mm256_loadu_si256((__m256i*)(buffers[x] + i))); \
+        inout_val = _mm512_add_ps(inout_val, in##x##_val);                                   \
+    } while (0)
+
+// Reduce functions down below use vectorized algorithm, the number of bytes processed each
+// iteration depends on vector length.  256bit vector ==> 32 bytes, 512bit vector ==> 64 bytes
+// If you change implementation of reduce_bf16_buffers, etc. , check whether this number needs
+// to be changed
+#define VECTOR_LENGTH_IN_BYTES 32
+
+void reduce_bf16_buffers(int start_elements, int num_elements, char* to_buffer, char** buffers)
+{
+    const int element_size = 2;
+    const int vector_length = VECTOR_LENGTH_IN_BYTES / element_size;
+    int main_elements = num_elements - (num_elements % vector_length);
+    int remain_elements = num_elements % vector_length;
+
+    // process aligned part
+#pragma omp parallel for
+    for (int i = start_elements * element_size; i < (start_elements + main_elements) * element_size;
+         i += VECTOR_LENGTH_IN_BYTES) {
+        auto inout_val = cvt_bf16_to_fp32(_mm256_loadu_si256((__m256i*)(buffers[0] + i)));
+        switch (world_size) {
+            case 16: CVT_ADD_BF16(15);
+            case 15: CVT_ADD_BF16(14);
+            case 14: CVT_ADD_BF16(13);
+            case 13: CVT_ADD_BF16(12);
+            case 12: CVT_ADD_BF16(11);
+            case 11: CVT_ADD_BF16(10);
+            case 10: CVT_ADD_BF16(9);
+            case 9: CVT_ADD_BF16(8);
+            case 8: CVT_ADD_BF16(7);
+            case 7: CVT_ADD_BF16(6);
+            case 6: CVT_ADD_BF16(5);
+            case 5: CVT_ADD_BF16(4);
+            case 4: CVT_ADD_BF16(3);
+            case 3: CVT_ADD_BF16(2);
+            case 2: CVT_ADD_BF16(1);
+            case 1: break;
+            default:
+                for (int j = 1; j < world_size; j++) {
+                    auto in_val = cvt_bf16_to_fp32(_mm256_loadu_si256((__m256i*)(buffers[j] + i)));
+                    inout_val = _mm512_add_ps(inout_val, in_val);
+                }
+        }
+        _mm256_storeu_si256((__m256i*)(to_buffer + i), cvt_fp32_to_bf16(inout_val));
+    }
+
+    // process remaining part
+    int i = (start_elements + main_elements) * element_size;
+    while (remain_elements > 0) {
+        float val = 0.0f;
+        for (int j = 0; j < world_size; j++) { val += *(at::BFloat16*)(buffers[j] + i); }
+        *(at::BFloat16*)(to_buffer + i) = val;
+        remain_elements--;
+        i += element_size;
+    }
+}
+
+#define CVT_ADD_FP16(x)                                                                      \
+    do {                                                                                     \
+        auto in##x##_val = cvt_fp16_to_fp32(_mm256_loadu_si256((__m256i*)(buffers[x] + i))); \
+        inout_val = _mm512_add_ps(inout_val, in##x##_val);                                   \
+    } while (0)
+
+void reduce_fp16_buffers(int start_elements, int num_elements, char* to_buffer, char** buffers)
+{
+    const int element_size = 2;
+    const int vector_length = VECTOR_LENGTH_IN_BYTES / element_size;
+    int main_elements = num_elements - (num_elements % vector_length);
+    int remain_elements = num_elements % vector_length;
+
+    // process aligned part
+#pragma omp parallel for
+    for (int i = start_elements * element_size; i < (start_elements + main_elements) * element_size;
+         i += VECTOR_LENGTH_IN_BYTES) {
+        auto inout_val = cvt_fp16_to_fp32(_mm256_loadu_si256((__m256i*)(buffers[0] + i)));
+        switch (world_size) {
+            case 16: CVT_ADD_FP16(15);
+            case 15: CVT_ADD_FP16(14);
+            case 14: CVT_ADD_FP16(13);
+            case 13: CVT_ADD_FP16(12);
+            case 12: CVT_ADD_FP16(11);
+            case 11: CVT_ADD_FP16(10);
+            case 10: CVT_ADD_FP16(9);
+            case 9: CVT_ADD_FP16(8);
+            case 8: CVT_ADD_FP16(7);
+            case 7: CVT_ADD_FP16(6);
+            case 6: CVT_ADD_FP16(5);
+            case 5: CVT_ADD_FP16(4);
+            case 4: CVT_ADD_FP16(3);
+            case 3: CVT_ADD_FP16(2);
+            case 2: CVT_ADD_FP16(1);
+            case 1: break;
+            default:
+                for (int j = 1; j < world_size; j++) {
+                    auto in_val = cvt_fp16_to_fp32(_mm256_loadu_si256((__m256i*)(buffers[j] + i)));
+                    inout_val = _mm512_add_ps(inout_val, in_val);
+                }
+        }
+        _mm256_storeu_si256((__m256i*)(to_buffer + i), cvt_fp32_to_fp16(inout_val));
+    }
+
+    // process remaining part
+    int i = (start_elements + main_elements) * element_size;
+    while (remain_elements > 0) {
+        float val = 0.0f;
+        for (int j = 0; j < world_size; j++) { val += *(at::Half*)(buffers[j] + i); }
+        *(at::Half*)(to_buffer + i) = val;
+        remain_elements--;
+        i += element_size;
+    }
+}
+
+#define CVT_ADD_F32(x)                                                \
+    do {                                                              \
+        auto in##x##_val = _mm256_loadu_ps((float*)(buffers[x] + i)); \
+        inout_val = _mm256_add_ps(inout_val, in##x##_val);            \
+    } while (0)
+
+void reduce_fp32_buffers(int start_elements, int num_elements, char* to_buffer, char** buffers)
+{
+    const int element_size = 4;
+    const int vector_length = VECTOR_LENGTH_IN_BYTES / element_size;
+    int main_elements = num_elements - (num_elements % vector_length);
+    int remain_elements = num_elements % vector_length;
+
+    // process aligned part
+#pragma omp parallel for
+    for (int i = start_elements * element_size; i < (start_elements + main_elements) * element_size;
+         i += VECTOR_LENGTH_IN_BYTES) {
+        auto inout_val = _mm256_loadu_ps((float*)(buffers[0] + i));
+        switch (world_size) {
+            case 16: CVT_ADD_F32(15);
+            case 15: CVT_ADD_F32(14);
+            case 14: CVT_ADD_F32(13);
+            case 13: CVT_ADD_F32(12);
+            case 12: CVT_ADD_F32(11);
+            case 11: CVT_ADD_F32(10);
+            case 10: CVT_ADD_F32(9);
+            case 9: CVT_ADD_F32(8);
+            case 8: CVT_ADD_F32(7);
+            case 7: CVT_ADD_F32(6);
+            case 6: CVT_ADD_F32(5);
+            case 5: CVT_ADD_F32(4);
+            case 4: CVT_ADD_F32(3);
+            case 3: CVT_ADD_F32(2);
+            case 2: CVT_ADD_F32(1);
+            case 1: break;
+            default:
+                for (int j = 1; j < world_size; j++) {
+                    auto in_val = _mm256_loadu_ps((float*)(buffers[j] + i));
+                    inout_val = _mm256_add_ps(inout_val, in_val);
+                }
+        }
+        _mm256_storeu_ps((float*)(to_buffer + i), inout_val);
+    }
+
+    // process remaining part
+    int i = (start_elements + main_elements) * element_size;
+    while (remain_elements > 0) {
+        float val = 0.0f;
+        for (int j = 0; j < world_size; j++) { val += *(float*)(buffers[j] + i); }
+        *(float*)(to_buffer + i) = val;
+        remain_elements--;
+        i += element_size;
+    }
+}
+
+static bool is_initialized = 0;
+static int world_rank;
+
+void shm_initialize(int size, int rank, char* addr_string, char* port_string)
+{
+    if (is_initialized) return;
+    is_initialized = 1;
+
+    world_size = size;
+    world_rank = rank;
+
+    char shm_name_prefix[NAME_BUF_SIZE];
+    char shm_name[NAME_BUF_SIZE];
+    snprintf(shm_name_prefix,
+             NAME_BUF_SIZE,
+             "%s_%d_%s_%s",
+             SHM_BUFFER_NAME,
+             getuid(),
+             addr_string,
+             port_string);
+    // create shared workspace for SHM based allreduce
+    SharedData allreduce_buffer;
+    // allocate workspace_buf for current rank
+    struct allreduce_workspace* workspace_buf;
+    struct allreduce_workspace* workspace_buf_other;
+    workspace_buf = (struct allreduce_workspace*)malloc(sizeof(struct allreduce_workspace));
+    snprintf(shm_name, NAME_BUF_SIZE, "%s_%d", shm_name_prefix, rank);
+    shared_create(&allreduce_buffer, shm_name, workspace_buf, sizeof(struct allreduce_workspace));
+    workspace_buf = (struct allreduce_workspace*)allreduce_buffer.bytes;
+    workspace_buf->states[0] = coll_alt2_allreduce_naive__copy_in_done;
+    workspace_buf->states[1] = coll_begin;
+
+    // create the workspace pointer list
+    workspace = (struct allreduce_workspace**)malloc(size * sizeof(struct allreduce_workspace*));
+    symmetric_buffer[0] = (char**)malloc(size * sizeof(char**));
+    symmetric_buffer[1] = (char**)malloc(size * sizeof(char**));
+    distributed_buffer[0] = (char**)malloc(size * sizeof(char**));
+    distributed_buffer[1] = (char**)malloc(size * sizeof(char**));
+
+    // map shm of all ranks
+    for (int i = 0; i < size; i++) {
+        if (i != rank) {
+            snprintf(shm_name, NAME_BUF_SIZE, "%s_%d", shm_name_prefix, i);
+            // printf("open %s, %d\n", shm_name, rank);
+            do {
+                shared_open(&allreduce_buffer, shm_name, sizeof(struct allreduce_workspace));
+            } while (allreduce_buffer.descriptor == -1 && errno == ENOENT);
+            workspace_buf_other = (struct allreduce_workspace*)allreduce_buffer.bytes;
+            workspace[i] = workspace_buf_other;
+        } else {
+            workspace[i] = workspace_buf;
+        }
+        symmetric_buffer[0][i] = workspace[i]->buffer + BUFFER0_OFFSET(0);
+        symmetric_buffer[1][i] = workspace[i]->buffer + BUFFER0_OFFSET(1);
+        distributed_buffer[0][i] = workspace[i]->buffer + BUFFER1_OFFSET(0);
+        distributed_buffer[1][i] = workspace[i]->buffer + BUFFER1_OFFSET(1);
+    }
+}
+
+static void parallel_memcpy(void* to, void* from, size_t n_bytes)
+    __attribute__((target("avx512bw")));
+static void parallel_memcpy(void* to, void* from, size_t n_bytes)
+{
+    auto aligned_bytes = n_bytes - (n_bytes % VECTOR_LENGTH_IN_BYTES);
+    // process aligned part
+#pragma omp parallel for
+    for (int i = 0; i < aligned_bytes; i += VECTOR_LENGTH_IN_BYTES) {
+        auto val = _mm256_loadu_si256((__m256i*)((char*)from + i));
+        _mm256_storeu_si256((__m256i*)((char*)to + i), val);
+    }
+
+    // process remaining part
+    for (int i = aligned_bytes; i < n_bytes; i++) { *((char*)to + i) = *((char*)from + i); }
+}
+
+#define positive_mod(num, mod) ((((num) % (mod)) + (mod)) % (mod))
+#define rank_mod(rank) positive_mod(rank, world_size)
+size_t slice_size(size_t chunk_el, int slice_idx)
+{
+    size_t slice_size = chunk_el / world_size;
+    return slice_idx == world_size - 1 ? slice_size + (chunk_el % world_size) : slice_size;
+}
+
+char* slice_data(char* data_ptr, size_t chunk_el, int el_size, int slice_idx)
+{
+    size_t slice_size = chunk_el / world_size;
+    size_t el_offset = slice_size * slice_idx;
+    return data_ptr + el_offset * el_size;
+}
+
+size_t slice_el_start(size_t chunk_el, int slice_idx)
+{
+    size_t slice_size = chunk_el / world_size;
+    return slice_size * slice_idx;
+}
+
+void symmetric_naive_all_reduce(char* data_ptr,
+                                c10::ScalarType scalar_type,
+                                size_t chunk_size,
+                                size_t chunk_el)
+{
+    const int state_group = 0;
+    static int current_buffer = 0;
+    static int state_idx = 0;
+
+    enum coll_state copy_current, copy_next;
+
+    switch (state_idx) {
+        case 0:
+            copy_current = coll_allreduce_naive__copy_in_done;
+            copy_next = coll_alt1_allreduce_naive__copy_in_done;
+            break;
+        case 1:
+            copy_current = coll_alt1_allreduce_naive__copy_in_done;
+            copy_next = coll_alt2_allreduce_naive__copy_in_done;
+            break;
+        case 2:
+            copy_current = coll_alt2_allreduce_naive__copy_in_done;
+            copy_next = coll_allreduce_naive__copy_in_done;
+            break;
+        default: assert(!"Should not get here.");
+    }
+    state_idx = (state_idx + 1) % 3;
+
+    parallel_memcpy(symmetric_buffer[current_buffer][world_rank], data_ptr, chunk_size);
+    std::atomic_thread_fence(std::memory_order_release);
+    workspace[world_rank]->states[state_group] = copy_current;
+
+    for (int i = 0; i < world_size; i++) {
+        // wait until the other rank copy the buffer
+        if (i != world_rank) { wait_buffer_state_until_2(i, copy_current, copy_next, state_group); }
+    }
+
+    // each rank reduce the buffer independently so therre is no need for synchronization afterward
+    reduce_all_buffers(
+        0, chunk_el, scalar_type, world_rank, data_ptr, symmetric_buffer[current_buffer]);
+
+    // switch buffer
+    current_buffer = 1 - current_buffer;
+}
+
+// naive allreduce distributed, each rank do naive reduce on its slice
+void distributed_naive_reduce(char* data_ptr,
+                              c10::ScalarType scalar_type,
+                              size_t chunk_size,
+                              size_t chunk_el)
+{
+    const int state_group = 1;
+    static int current_buffer = 0;
+    static int state_idx = 0;
+
+    enum coll_state copy_current, copy_next, reduce_current;
+
+    // similar to symmetric_naive_allreduce, but here we only need two sets of
+    // states, because distributed naive reduce has two barriers in the algorithm
+    switch (state_idx) {
+        case 0:
+            copy_current = coll_allreduce_naive__copy_in_done;
+            reduce_current = coll_allreduce_naive__reduce_done;
+            copy_next = coll_alt1_allreduce_naive__copy_in_done;
+            break;
+        case 1:
+            copy_current = coll_alt1_allreduce_naive__copy_in_done;
+            reduce_current = coll_alt1_allreduce_naive__reduce_done;
+            copy_next = coll_allreduce_naive__copy_in_done;
+            break;
+        default: assert(!"Should not get here.");
+    }
+    state_idx = (state_idx + 1) % 2;
+
+    int data_size = chunk_size / chunk_el;
+    parallel_memcpy(distributed_buffer[current_buffer][world_rank], data_ptr, chunk_size);
+    std::atomic_thread_fence(std::memory_order_release);
+    workspace[world_rank]->states[state_group] = copy_current;
+
+    for (int i = 0; i < world_size; i++) {
+        // wait until all the other ranks copy the buffer
+        if (i != world_rank)
+            wait_buffer_state_until_2(i, copy_current, reduce_current, state_group);
+    }
+
+    // reduce scatter
+    reduce_all_buffers(slice_el_start(chunk_el, world_rank),
+                       slice_size(chunk_el, world_rank),
+                       scalar_type,
+                       world_rank,
+                       distributed_buffer[current_buffer][world_rank],
+                       distributed_buffer[current_buffer]);
+    std::atomic_thread_fence(std::memory_order_release);
+    workspace[world_rank]->states[state_group] = reduce_current;
+
+    for (int i = 0; i < world_size; i++) {
+        // wait until all the other ranks reduce the buffer
+        if (i != world_rank) wait_buffer_state_until_2(i, reduce_current, copy_next, state_group);
+    }
+
+    auto t4 = std::chrono::system_clock::now();
+
+    for (int i = 0; i < world_size; i++) {
+        int rank = (i + world_rank) % world_size;
+        parallel_memcpy(
+            slice_data(data_ptr, chunk_el, data_size, rank),
+            slice_data(
+                distributed_buffer[current_buffer][rank], chunk_el, chunk_size / chunk_el, rank),
+            slice_size(chunk_el, rank) * data_size);
+    }
+
+    current_buffer = 1 - current_buffer;
+}
+
+void all_reduce_outer_loop(torch::Tensor& data, size_t numel, int data_size)
+{
+    for (int offset = 0; offset < data_size; offset += MAX_BUF_SIZE) {
+        auto data_ptr = ((char*)(data.data_ptr()) + offset);
+        size_t chunk_size = data_size - offset > MAX_BUF_SIZE ? MAX_BUF_SIZE : data_size - offset;
+        size_t chunk_el = chunk_size / (data_size / numel);
+        if (chunk_size < NAIVE_ALLREDUCE_THRESHOLD) {
+            symmetric_naive_all_reduce(data_ptr, data.scalar_type(), chunk_size, chunk_el);
+        }
+        else {
+            distributed_naive_reduce(data_ptr, data.scalar_type(), chunk_size, chunk_el);
+        }
+    }
+}

--- a/sgl-kernel/src/sgl-kernel/csrc/cpu/shm.cpp
+++ b/sgl-kernel/src/sgl-kernel/csrc/cpu/shm.cpp
@@ -428,13 +428,14 @@ void reduce_fp32_buffers(
   }
 }
 
-static bool is_initialized = 0;
+static bool is_initialized = false;
 static int world_rank;
 
 void shm_initialize(int size, int rank, char* addr_string, char* port_string) {
-  if (is_initialized)
+  if (is_initialized) {
     return;
-  is_initialized = 1;
+  }
+  is_initialized = true;
 
   world_size = size;
   world_rank = rank;
@@ -644,8 +645,6 @@ void distributed_naive_reduce(
     if (i != world_rank)
       wait_buffer_state_until_2(i, reduce_current, copy_next, state_group);
   }
-
-  auto t4 = std::chrono::system_clock::now();
 
   for (int i = 0; i < world_size; i++) {
     int rank = (i + world_rank) % world_size;

--- a/sgl-kernel/src/sgl-kernel/csrc/cpu/shm.cpp
+++ b/sgl-kernel/src/sgl-kernel/csrc/cpu/shm.cpp
@@ -1,63 +1,66 @@
 #include <ATen/ATen.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <immintrin.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/mman.h>
 #include <unistd.h>
-#include <immintrin.h>
 
 #include "shm.h"
 
 // states for collectives
 enum coll_state {
-    coll_begin = 0,
-    coll_allreduce_naive__copy_in_done,
-    coll_allreduce_naive__reduce_done,
-    // alternative state when allreduce is working on alternative buffer
-    // of the double buffer.
-    coll_alt1_allreduce_naive__copy_in_done,
-    coll_alt2_allreduce_naive__copy_in_done,
-    coll_alt1_allreduce_naive__reduce_done,
+  coll_begin = 0,
+  coll_allreduce_naive__copy_in_done,
+  coll_allreduce_naive__reduce_done,
+  // alternative state when allreduce is working on alternative buffer
+  // of the double buffer.
+  coll_alt1_allreduce_naive__copy_in_done,
+  coll_alt2_allreduce_naive__copy_in_done,
+  coll_alt1_allreduce_naive__reduce_done,
 };
 
 // SHM building blocks
 struct SharedData {
-    const char* name;
-    int descriptor;
-    void* bytes;
-    size_t nbytes;
+  const char* name;
+  int descriptor;
+  void* bytes;
+  size_t nbytes;
 };
 
-void shared_open(SharedData* data, const char* name, size_t nbytes)
-{
-    int d = shm_open(name, O_RDWR, S_IRUSR | S_IWUSR);
-    if (d != -1) {
-        void* bytes = mmap(NULL, nbytes, PROT_READ | PROT_WRITE, MAP_SHARED, d, 0);
-        data->name = name;
-        data->descriptor = d;
-        data->bytes = bytes;
-        data->nbytes = nbytes;
-    } else {
-        if (errno != ENOENT) {
-            // don't print if shm can not be found because we want to loop over from
-            // caller again until the other ranks created the shm
-            printf("shared_open %s failed, errno=%d\n", name, errno);
-        }
-        data->descriptor = -1;
+void shared_open(SharedData* data, const char* name, size_t nbytes) {
+  int d = shm_open(name, O_RDWR, S_IRUSR | S_IWUSR);
+  if (d != -1) {
+    void* bytes = mmap(NULL, nbytes, PROT_READ | PROT_WRITE, MAP_SHARED, d, 0);
+    data->name = name;
+    data->descriptor = d;
+    data->bytes = bytes;
+    data->nbytes = nbytes;
+  } else {
+    if (errno != ENOENT) {
+      // don't print if shm can not be found because we want to loop over from
+      // caller again until the other ranks created the shm
+      printf("shared_open %s failed, errno=%d\n", name, errno);
     }
+    data->descriptor = -1;
+  }
 }
 
-
-void shared_create(SharedData* data, const char* name, void* bytes, size_t nbytes)
-{
-    int d = shm_open(name, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
-    if (d != -1) {
-        if (nbytes = write(d, bytes, nbytes)) { shared_open(data, name, nbytes); }
-    } else {
-        printf("shared_create %s failed\n", name);
+void shared_create(
+    SharedData* data,
+    const char* name,
+    void* bytes,
+    size_t nbytes) {
+  int d = shm_open(name, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+  if (d != -1) {
+    if (nbytes = write(d, bytes, nbytes)) {
+      shared_open(data, name, nbytes);
     }
+  } else {
+    printf("shared_create %s failed\n", name);
+  }
 }
 
 static int world_size;
@@ -69,16 +72,18 @@ static int world_size;
 #define NAIVE_ALLREDUCE_THRESHOLD 1048576
 #define SHM_BUFFER_NAME "deepspeed_allreduce_buffer"
 struct allreduce_workspace {
-    enum coll_state states[2];  // idx=0 -- state for symmetric_naive_all_reduce
-                                // idx=1 -- state for distributed_naive_all_reduce
-    // double buffer to avoid syncing between rounds
-    // offset=0 -- 2*NAIVE_ALLREDUCE_THRESHOLD : buffer for symmetric_naive_all_reduce
-    // after that : buffer for distributed_naive_all_reduce
-    char buffer[2 * NAIVE_ALLREDUCE_THRESHOLD + 2 * MAX_BUF_SIZE];
+  enum coll_state states[2]; // idx=0 -- state for symmetric_naive_all_reduce
+                             // idx=1 -- state for distributed_naive_all_reduce
+  // double buffer to avoid syncing between rounds
+  // offset=0 -- 2*NAIVE_ALLREDUCE_THRESHOLD : buffer for
+  // symmetric_naive_all_reduce after that : buffer for
+  // distributed_naive_all_reduce
+  char buffer[2 * NAIVE_ALLREDUCE_THRESHOLD + 2 * MAX_BUF_SIZE];
 };
 
 #define BUFFER0_OFFSET(current_buffer) current_buffer* NAIVE_ALLREDUCE_THRESHOLD
-#define BUFFER1_OFFSET(current_buffer) 2 * NAIVE_ALLREDUCE_THRESHOLD + current_buffer* MAX_BUF_SIZE
+#define BUFFER1_OFFSET(current_buffer) \
+  2 * NAIVE_ALLREDUCE_THRESHOLD + current_buffer* MAX_BUF_SIZE
 
 struct allreduce_workspace** workspace;
 
@@ -87,478 +92,588 @@ char** symmetric_buffer[2];
 // buffer for large messages, double buffer
 char** distributed_buffer[2];
 
-void wait_buffer_state_until_2(int index,
-                               enum coll_state state0,
-                               enum coll_state state1,
-                               int state_group)
-{
-    volatile enum coll_state* state_ptr = &(workspace[index]->states[state_group]);
+void wait_buffer_state_until_2(
+    int index,
+    enum coll_state state0,
+    enum coll_state state1,
+    int state_group) {
+  volatile enum coll_state* state_ptr =
+      &(workspace[index]->states[state_group]);
 
-    while (1) {
-        volatile enum coll_state cur_state = *state_ptr;
-        if (cur_state == state0 || cur_state == state1) break;
-    }
+  while (1) {
+    volatile enum coll_state cur_state = *state_ptr;
+    if (cur_state == state0 || cur_state == state1)
+      break;
+  }
 }
 
 __m512 cvt_bf16_to_fp32(const __m256i src) __attribute__((target("avx512bw")));
-inline __m512 cvt_bf16_to_fp32(const __m256i src)
-{
-    auto y = _mm512_cvtepu16_epi32(src);
-    return _mm512_castsi512_ps(_mm512_bslli_epi128(y, 2));
+inline __m512 cvt_bf16_to_fp32(const __m256i src) {
+  auto y = _mm512_cvtepu16_epi32(src);
+  return _mm512_castsi512_ps(_mm512_bslli_epi128(y, 2));
 }
 
-inline __m256i cvt_fp32_to_bf16(const __m512 src) __attribute__((target("avx512bw")));
 inline __m256i cvt_fp32_to_bf16(const __m512 src)
-{
-    __m512i value = _mm512_castps_si512(src);
-    __m512i nan = _mm512_set1_epi32(0xffff);
-    auto mask_value = _mm512_cmp_ps_mask(src, src, _CMP_ORD_Q);
-    __m512i ones = _mm512_set1_epi32(0x1);
-    __m512i vec_bias = _mm512_set1_epi32(0x7fff);
-    // uint32_t lsb = (input >> 16) & 1;
-    auto t_value = _mm512_and_si512(_mm512_srli_epi32(value, 16), ones);
-    // uint32_t rounding_bias = 0x7fff + lsb;
-    t_value = _mm512_add_epi32(t_value, vec_bias);
-    // input += rounding_bias;
-    t_value = _mm512_add_epi32(t_value, value);
-    // input = input >> 16;
-    t_value = _mm512_srli_epi32(t_value, 16);
-    // Check NaN before converting back to bf16
-    t_value = _mm512_mask_blend_epi32(mask_value, nan, t_value);
-    return _mm512_cvtusepi32_epi16(t_value);
+    __attribute__((target("avx512bw")));
+inline __m256i cvt_fp32_to_bf16(const __m512 src) {
+  __m512i value = _mm512_castps_si512(src);
+  __m512i nan = _mm512_set1_epi32(0xffff);
+  auto mask_value = _mm512_cmp_ps_mask(src, src, _CMP_ORD_Q);
+  __m512i ones = _mm512_set1_epi32(0x1);
+  __m512i vec_bias = _mm512_set1_epi32(0x7fff);
+  // uint32_t lsb = (input >> 16) & 1;
+  auto t_value = _mm512_and_si512(_mm512_srli_epi32(value, 16), ones);
+  // uint32_t rounding_bias = 0x7fff + lsb;
+  t_value = _mm512_add_epi32(t_value, vec_bias);
+  // input += rounding_bias;
+  t_value = _mm512_add_epi32(t_value, value);
+  // input = input >> 16;
+  t_value = _mm512_srli_epi32(t_value, 16);
+  // Check NaN before converting back to bf16
+  t_value = _mm512_mask_blend_epi32(mask_value, nan, t_value);
+  return _mm512_cvtusepi32_epi16(t_value);
 }
 
 __m512 cvt_fp16_to_fp32(const __m256i src) __attribute__((target("avx512bw")));
-inline __m512 cvt_fp16_to_fp32(const __m256i src) { return _mm512_cvtph_ps(src); }
+inline __m512 cvt_fp16_to_fp32(const __m256i src) {
+  return _mm512_cvtph_ps(src);
+}
 
-inline __m256i cvt_fp32_to_fp16(const __m512 src) __attribute__((target("avx512bw")));
 inline __m256i cvt_fp32_to_fp16(const __m512 src)
-{
-    return _mm512_cvtps_ph(src, (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC));
+    __attribute__((target("avx512bw")));
+inline __m256i cvt_fp32_to_fp16(const __m512 src) {
+  return _mm512_cvtps_ph(src, (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC));
 }
 
-void reduce_bf16_buffers(int start_elements, int num_elements, char* to_buffer, char** buffers)
-    __attribute__((target("avx512bw")));
+void reduce_bf16_buffers(
+    int start_elements,
+    int num_elements,
+    char* to_buffer,
+    char** buffers) __attribute__((target("avx512bw")));
 
-void reduce_fp16_buffers(int start_elements, int num_elements, char* to_buffer, char** buffers)
-    __attribute__((target("avx512bw")));
+void reduce_fp16_buffers(
+    int start_elements,
+    int num_elements,
+    char* to_buffer,
+    char** buffers) __attribute__((target("avx512bw")));
 
-void reduce_fp32_buffers(int start_elements, int num_elements, char* to_buffer, char** buffers)
-    __attribute__((target("avx512bw")));
+void reduce_fp32_buffers(
+    int start_elements,
+    int num_elements,
+    char* to_buffer,
+    char** buffers) __attribute__((target("avx512bw")));
 
-void reduce_all_buffers(int start_elements,
-                        int num_elements,
-                        c10::ScalarType scalar_type,
-                        int to_buffer_idx,
-                        char* to_buffer,
-                        char** buffers)
-{
-    switch (scalar_type) {
-        case c10::ScalarType::BFloat16:
-            reduce_bf16_buffers(start_elements, num_elements, to_buffer, buffers);
-            break;
-        case c10::ScalarType::Half:
-            reduce_fp16_buffers(start_elements, num_elements, to_buffer, buffers);
-            break;
-        case c10::ScalarType::Float:
-            reduce_fp32_buffers(start_elements, num_elements, to_buffer, buffers);
-            break;
-        default: assert(!"Should not get here");
-    }
+void reduce_all_buffers(
+    int start_elements,
+    int num_elements,
+    c10::ScalarType scalar_type,
+    int to_buffer_idx,
+    char* to_buffer,
+    char** buffers) {
+  switch (scalar_type) {
+    case c10::ScalarType::BFloat16:
+      reduce_bf16_buffers(start_elements, num_elements, to_buffer, buffers);
+      break;
+    case c10::ScalarType::Half:
+      reduce_fp16_buffers(start_elements, num_elements, to_buffer, buffers);
+      break;
+    case c10::ScalarType::Float:
+      reduce_fp32_buffers(start_elements, num_elements, to_buffer, buffers);
+      break;
+    default:
+      assert(!"Should not get here");
+  }
 }
 
-#define CVT_ADD_BF16(x)                                                                      \
-    do {                                                                                     \
-        auto in##x##_val = cvt_bf16_to_fp32(_mm256_loadu_si256((__m256i*)(buffers[x] + i))); \
-        inout_val = _mm512_add_ps(inout_val, in##x##_val);                                   \
-    } while (0)
+#define CVT_ADD_BF16(x)                                                   \
+  do {                                                                    \
+    auto in##x##_val =                                                    \
+        cvt_bf16_to_fp32(_mm256_loadu_si256((__m256i*)(buffers[x] + i))); \
+    inout_val = _mm512_add_ps(inout_val, in##x##_val);                    \
+  } while (0)
 
-// Reduce functions down below use vectorized algorithm, the number of bytes processed each
-// iteration depends on vector length.  256bit vector ==> 32 bytes, 512bit vector ==> 64 bytes
-// If you change implementation of reduce_bf16_buffers, etc. , check whether this number needs
-// to be changed
+// Reduce functions down below use vectorized algorithm, the number of bytes
+// processed each iteration depends on vector length.  256bit vector ==> 32
+// bytes, 512bit vector ==> 64 bytes If you change implementation of
+// reduce_bf16_buffers, etc. , check whether this number needs to be changed
 #define VECTOR_LENGTH_IN_BYTES 32
 
-void reduce_bf16_buffers(int start_elements, int num_elements, char* to_buffer, char** buffers)
-{
-    const int element_size = 2;
-    const int vector_length = VECTOR_LENGTH_IN_BYTES / element_size;
-    int main_elements = num_elements - (num_elements % vector_length);
-    int remain_elements = num_elements % vector_length;
+void reduce_bf16_buffers(
+    int start_elements,
+    int num_elements,
+    char* to_buffer,
+    char** buffers) {
+  const int element_size = 2;
+  const int vector_length = VECTOR_LENGTH_IN_BYTES / element_size;
+  int main_elements = num_elements - (num_elements % vector_length);
+  int remain_elements = num_elements % vector_length;
 
-    // process aligned part
+  // process aligned part
 #pragma omp parallel for
-    for (int i = start_elements * element_size; i < (start_elements + main_elements) * element_size;
-         i += VECTOR_LENGTH_IN_BYTES) {
-        auto inout_val = cvt_bf16_to_fp32(_mm256_loadu_si256((__m256i*)(buffers[0] + i)));
-        switch (world_size) {
-            case 16: CVT_ADD_BF16(15);
-            case 15: CVT_ADD_BF16(14);
-            case 14: CVT_ADD_BF16(13);
-            case 13: CVT_ADD_BF16(12);
-            case 12: CVT_ADD_BF16(11);
-            case 11: CVT_ADD_BF16(10);
-            case 10: CVT_ADD_BF16(9);
-            case 9: CVT_ADD_BF16(8);
-            case 8: CVT_ADD_BF16(7);
-            case 7: CVT_ADD_BF16(6);
-            case 6: CVT_ADD_BF16(5);
-            case 5: CVT_ADD_BF16(4);
-            case 4: CVT_ADD_BF16(3);
-            case 3: CVT_ADD_BF16(2);
-            case 2: CVT_ADD_BF16(1);
-            case 1: break;
-            default:
-                for (int j = 1; j < world_size; j++) {
-                    auto in_val = cvt_bf16_to_fp32(_mm256_loadu_si256((__m256i*)(buffers[j] + i)));
-                    inout_val = _mm512_add_ps(inout_val, in_val);
-                }
+  for (int i = start_elements * element_size;
+       i < (start_elements + main_elements) * element_size;
+       i += VECTOR_LENGTH_IN_BYTES) {
+    auto inout_val =
+        cvt_bf16_to_fp32(_mm256_loadu_si256((__m256i*)(buffers[0] + i)));
+    switch (world_size) {
+      case 16:
+        CVT_ADD_BF16(15);
+      case 15:
+        CVT_ADD_BF16(14);
+      case 14:
+        CVT_ADD_BF16(13);
+      case 13:
+        CVT_ADD_BF16(12);
+      case 12:
+        CVT_ADD_BF16(11);
+      case 11:
+        CVT_ADD_BF16(10);
+      case 10:
+        CVT_ADD_BF16(9);
+      case 9:
+        CVT_ADD_BF16(8);
+      case 8:
+        CVT_ADD_BF16(7);
+      case 7:
+        CVT_ADD_BF16(6);
+      case 6:
+        CVT_ADD_BF16(5);
+      case 5:
+        CVT_ADD_BF16(4);
+      case 4:
+        CVT_ADD_BF16(3);
+      case 3:
+        CVT_ADD_BF16(2);
+      case 2:
+        CVT_ADD_BF16(1);
+      case 1:
+        break;
+      default:
+        for (int j = 1; j < world_size; j++) {
+          auto in_val =
+              cvt_bf16_to_fp32(_mm256_loadu_si256((__m256i*)(buffers[j] + i)));
+          inout_val = _mm512_add_ps(inout_val, in_val);
         }
-        _mm256_storeu_si256((__m256i*)(to_buffer + i), cvt_fp32_to_bf16(inout_val));
     }
+    _mm256_storeu_si256((__m256i*)(to_buffer + i), cvt_fp32_to_bf16(inout_val));
+  }
 
-    // process remaining part
-    int i = (start_elements + main_elements) * element_size;
-    while (remain_elements > 0) {
-        float val = 0.0f;
-        for (int j = 0; j < world_size; j++) { val += *(at::BFloat16*)(buffers[j] + i); }
-        *(at::BFloat16*)(to_buffer + i) = val;
-        remain_elements--;
-        i += element_size;
+  // process remaining part
+  int i = (start_elements + main_elements) * element_size;
+  while (remain_elements > 0) {
+    float val = 0.0f;
+    for (int j = 0; j < world_size; j++) {
+      val += *(at::BFloat16*)(buffers[j] + i);
     }
+    *(at::BFloat16*)(to_buffer + i) = val;
+    remain_elements--;
+    i += element_size;
+  }
 }
 
-#define CVT_ADD_FP16(x)                                                                      \
-    do {                                                                                     \
-        auto in##x##_val = cvt_fp16_to_fp32(_mm256_loadu_si256((__m256i*)(buffers[x] + i))); \
-        inout_val = _mm512_add_ps(inout_val, in##x##_val);                                   \
-    } while (0)
+#define CVT_ADD_FP16(x)                                                   \
+  do {                                                                    \
+    auto in##x##_val =                                                    \
+        cvt_fp16_to_fp32(_mm256_loadu_si256((__m256i*)(buffers[x] + i))); \
+    inout_val = _mm512_add_ps(inout_val, in##x##_val);                    \
+  } while (0)
 
-void reduce_fp16_buffers(int start_elements, int num_elements, char* to_buffer, char** buffers)
-{
-    const int element_size = 2;
-    const int vector_length = VECTOR_LENGTH_IN_BYTES / element_size;
-    int main_elements = num_elements - (num_elements % vector_length);
-    int remain_elements = num_elements % vector_length;
+void reduce_fp16_buffers(
+    int start_elements,
+    int num_elements,
+    char* to_buffer,
+    char** buffers) {
+  const int element_size = 2;
+  const int vector_length = VECTOR_LENGTH_IN_BYTES / element_size;
+  int main_elements = num_elements - (num_elements % vector_length);
+  int remain_elements = num_elements % vector_length;
 
-    // process aligned part
+  // process aligned part
 #pragma omp parallel for
-    for (int i = start_elements * element_size; i < (start_elements + main_elements) * element_size;
-         i += VECTOR_LENGTH_IN_BYTES) {
-        auto inout_val = cvt_fp16_to_fp32(_mm256_loadu_si256((__m256i*)(buffers[0] + i)));
-        switch (world_size) {
-            case 16: CVT_ADD_FP16(15);
-            case 15: CVT_ADD_FP16(14);
-            case 14: CVT_ADD_FP16(13);
-            case 13: CVT_ADD_FP16(12);
-            case 12: CVT_ADD_FP16(11);
-            case 11: CVT_ADD_FP16(10);
-            case 10: CVT_ADD_FP16(9);
-            case 9: CVT_ADD_FP16(8);
-            case 8: CVT_ADD_FP16(7);
-            case 7: CVT_ADD_FP16(6);
-            case 6: CVT_ADD_FP16(5);
-            case 5: CVT_ADD_FP16(4);
-            case 4: CVT_ADD_FP16(3);
-            case 3: CVT_ADD_FP16(2);
-            case 2: CVT_ADD_FP16(1);
-            case 1: break;
-            default:
-                for (int j = 1; j < world_size; j++) {
-                    auto in_val = cvt_fp16_to_fp32(_mm256_loadu_si256((__m256i*)(buffers[j] + i)));
-                    inout_val = _mm512_add_ps(inout_val, in_val);
-                }
+  for (int i = start_elements * element_size;
+       i < (start_elements + main_elements) * element_size;
+       i += VECTOR_LENGTH_IN_BYTES) {
+    auto inout_val =
+        cvt_fp16_to_fp32(_mm256_loadu_si256((__m256i*)(buffers[0] + i)));
+    switch (world_size) {
+      case 16:
+        CVT_ADD_FP16(15);
+      case 15:
+        CVT_ADD_FP16(14);
+      case 14:
+        CVT_ADD_FP16(13);
+      case 13:
+        CVT_ADD_FP16(12);
+      case 12:
+        CVT_ADD_FP16(11);
+      case 11:
+        CVT_ADD_FP16(10);
+      case 10:
+        CVT_ADD_FP16(9);
+      case 9:
+        CVT_ADD_FP16(8);
+      case 8:
+        CVT_ADD_FP16(7);
+      case 7:
+        CVT_ADD_FP16(6);
+      case 6:
+        CVT_ADD_FP16(5);
+      case 5:
+        CVT_ADD_FP16(4);
+      case 4:
+        CVT_ADD_FP16(3);
+      case 3:
+        CVT_ADD_FP16(2);
+      case 2:
+        CVT_ADD_FP16(1);
+      case 1:
+        break;
+      default:
+        for (int j = 1; j < world_size; j++) {
+          auto in_val =
+              cvt_fp16_to_fp32(_mm256_loadu_si256((__m256i*)(buffers[j] + i)));
+          inout_val = _mm512_add_ps(inout_val, in_val);
         }
-        _mm256_storeu_si256((__m256i*)(to_buffer + i), cvt_fp32_to_fp16(inout_val));
     }
+    _mm256_storeu_si256((__m256i*)(to_buffer + i), cvt_fp32_to_fp16(inout_val));
+  }
 
-    // process remaining part
-    int i = (start_elements + main_elements) * element_size;
-    while (remain_elements > 0) {
-        float val = 0.0f;
-        for (int j = 0; j < world_size; j++) { val += *(at::Half*)(buffers[j] + i); }
-        *(at::Half*)(to_buffer + i) = val;
-        remain_elements--;
-        i += element_size;
+  // process remaining part
+  int i = (start_elements + main_elements) * element_size;
+  while (remain_elements > 0) {
+    float val = 0.0f;
+    for (int j = 0; j < world_size; j++) {
+      val += *(at::Half*)(buffers[j] + i);
     }
+    *(at::Half*)(to_buffer + i) = val;
+    remain_elements--;
+    i += element_size;
+  }
 }
 
-#define CVT_ADD_F32(x)                                                \
-    do {                                                              \
-        auto in##x##_val = _mm256_loadu_ps((float*)(buffers[x] + i)); \
-        inout_val = _mm256_add_ps(inout_val, in##x##_val);            \
-    } while (0)
+#define CVT_ADD_F32(x)                                            \
+  do {                                                            \
+    auto in##x##_val = _mm256_loadu_ps((float*)(buffers[x] + i)); \
+    inout_val = _mm256_add_ps(inout_val, in##x##_val);            \
+  } while (0)
 
-void reduce_fp32_buffers(int start_elements, int num_elements, char* to_buffer, char** buffers)
-{
-    const int element_size = 4;
-    const int vector_length = VECTOR_LENGTH_IN_BYTES / element_size;
-    int main_elements = num_elements - (num_elements % vector_length);
-    int remain_elements = num_elements % vector_length;
+void reduce_fp32_buffers(
+    int start_elements,
+    int num_elements,
+    char* to_buffer,
+    char** buffers) {
+  const int element_size = 4;
+  const int vector_length = VECTOR_LENGTH_IN_BYTES / element_size;
+  int main_elements = num_elements - (num_elements % vector_length);
+  int remain_elements = num_elements % vector_length;
 
-    // process aligned part
+  // process aligned part
 #pragma omp parallel for
-    for (int i = start_elements * element_size; i < (start_elements + main_elements) * element_size;
-         i += VECTOR_LENGTH_IN_BYTES) {
-        auto inout_val = _mm256_loadu_ps((float*)(buffers[0] + i));
-        switch (world_size) {
-            case 16: CVT_ADD_F32(15);
-            case 15: CVT_ADD_F32(14);
-            case 14: CVT_ADD_F32(13);
-            case 13: CVT_ADD_F32(12);
-            case 12: CVT_ADD_F32(11);
-            case 11: CVT_ADD_F32(10);
-            case 10: CVT_ADD_F32(9);
-            case 9: CVT_ADD_F32(8);
-            case 8: CVT_ADD_F32(7);
-            case 7: CVT_ADD_F32(6);
-            case 6: CVT_ADD_F32(5);
-            case 5: CVT_ADD_F32(4);
-            case 4: CVT_ADD_F32(3);
-            case 3: CVT_ADD_F32(2);
-            case 2: CVT_ADD_F32(1);
-            case 1: break;
-            default:
-                for (int j = 1; j < world_size; j++) {
-                    auto in_val = _mm256_loadu_ps((float*)(buffers[j] + i));
-                    inout_val = _mm256_add_ps(inout_val, in_val);
-                }
+  for (int i = start_elements * element_size;
+       i < (start_elements + main_elements) * element_size;
+       i += VECTOR_LENGTH_IN_BYTES) {
+    auto inout_val = _mm256_loadu_ps((float*)(buffers[0] + i));
+    switch (world_size) {
+      case 16:
+        CVT_ADD_F32(15);
+      case 15:
+        CVT_ADD_F32(14);
+      case 14:
+        CVT_ADD_F32(13);
+      case 13:
+        CVT_ADD_F32(12);
+      case 12:
+        CVT_ADD_F32(11);
+      case 11:
+        CVT_ADD_F32(10);
+      case 10:
+        CVT_ADD_F32(9);
+      case 9:
+        CVT_ADD_F32(8);
+      case 8:
+        CVT_ADD_F32(7);
+      case 7:
+        CVT_ADD_F32(6);
+      case 6:
+        CVT_ADD_F32(5);
+      case 5:
+        CVT_ADD_F32(4);
+      case 4:
+        CVT_ADD_F32(3);
+      case 3:
+        CVT_ADD_F32(2);
+      case 2:
+        CVT_ADD_F32(1);
+      case 1:
+        break;
+      default:
+        for (int j = 1; j < world_size; j++) {
+          auto in_val = _mm256_loadu_ps((float*)(buffers[j] + i));
+          inout_val = _mm256_add_ps(inout_val, in_val);
         }
-        _mm256_storeu_ps((float*)(to_buffer + i), inout_val);
     }
+    _mm256_storeu_ps((float*)(to_buffer + i), inout_val);
+  }
 
-    // process remaining part
-    int i = (start_elements + main_elements) * element_size;
-    while (remain_elements > 0) {
-        float val = 0.0f;
-        for (int j = 0; j < world_size; j++) { val += *(float*)(buffers[j] + i); }
-        *(float*)(to_buffer + i) = val;
-        remain_elements--;
-        i += element_size;
+  // process remaining part
+  int i = (start_elements + main_elements) * element_size;
+  while (remain_elements > 0) {
+    float val = 0.0f;
+    for (int j = 0; j < world_size; j++) {
+      val += *(float*)(buffers[j] + i);
     }
+    *(float*)(to_buffer + i) = val;
+    remain_elements--;
+    i += element_size;
+  }
 }
 
 static bool is_initialized = 0;
 static int world_rank;
 
-void shm_initialize(int size, int rank, char* addr_string, char* port_string)
-{
-    if (is_initialized) return;
-    is_initialized = 1;
+void shm_initialize(int size, int rank, char* addr_string, char* port_string) {
+  if (is_initialized)
+    return;
+  is_initialized = 1;
 
-    world_size = size;
-    world_rank = rank;
+  world_size = size;
+  world_rank = rank;
 
-    char shm_name_prefix[NAME_BUF_SIZE];
-    char shm_name[NAME_BUF_SIZE];
-    snprintf(shm_name_prefix,
-             NAME_BUF_SIZE,
-             "%s_%d_%s_%s",
-             SHM_BUFFER_NAME,
-             getuid(),
-             addr_string,
-             port_string);
-    // create shared workspace for SHM based allreduce
-    SharedData allreduce_buffer;
-    // allocate workspace_buf for current rank
-    struct allreduce_workspace* workspace_buf;
-    struct allreduce_workspace* workspace_buf_other;
-    workspace_buf = (struct allreduce_workspace*)malloc(sizeof(struct allreduce_workspace));
-    snprintf(shm_name, NAME_BUF_SIZE, "%s_%d", shm_name_prefix, rank);
-    shared_create(&allreduce_buffer, shm_name, workspace_buf, sizeof(struct allreduce_workspace));
-    workspace_buf = (struct allreduce_workspace*)allreduce_buffer.bytes;
-    workspace_buf->states[0] = coll_alt2_allreduce_naive__copy_in_done;
-    workspace_buf->states[1] = coll_begin;
+  char shm_name_prefix[NAME_BUF_SIZE];
+  char shm_name[NAME_BUF_SIZE];
+  snprintf(
+      shm_name_prefix,
+      NAME_BUF_SIZE,
+      "%s_%d_%s_%s",
+      SHM_BUFFER_NAME,
+      getuid(),
+      addr_string,
+      port_string);
+  // create shared workspace for SHM based allreduce
+  SharedData allreduce_buffer;
+  // allocate workspace_buf for current rank
+  struct allreduce_workspace* workspace_buf;
+  struct allreduce_workspace* workspace_buf_other;
+  workspace_buf =
+      (struct allreduce_workspace*)malloc(sizeof(struct allreduce_workspace));
+  snprintf(shm_name, NAME_BUF_SIZE, "%s_%d", shm_name_prefix, rank);
+  shared_create(
+      &allreduce_buffer,
+      shm_name,
+      workspace_buf,
+      sizeof(struct allreduce_workspace));
+  workspace_buf = (struct allreduce_workspace*)allreduce_buffer.bytes;
+  workspace_buf->states[0] = coll_alt2_allreduce_naive__copy_in_done;
+  workspace_buf->states[1] = coll_begin;
 
-    // create the workspace pointer list
-    workspace = (struct allreduce_workspace**)malloc(size * sizeof(struct allreduce_workspace*));
-    symmetric_buffer[0] = (char**)malloc(size * sizeof(char**));
-    symmetric_buffer[1] = (char**)malloc(size * sizeof(char**));
-    distributed_buffer[0] = (char**)malloc(size * sizeof(char**));
-    distributed_buffer[1] = (char**)malloc(size * sizeof(char**));
+  // create the workspace pointer list
+  workspace = (struct allreduce_workspace**)malloc(
+      size * sizeof(struct allreduce_workspace*));
+  symmetric_buffer[0] = (char**)malloc(size * sizeof(char**));
+  symmetric_buffer[1] = (char**)malloc(size * sizeof(char**));
+  distributed_buffer[0] = (char**)malloc(size * sizeof(char**));
+  distributed_buffer[1] = (char**)malloc(size * sizeof(char**));
 
-    // map shm of all ranks
-    for (int i = 0; i < size; i++) {
-        if (i != rank) {
-            snprintf(shm_name, NAME_BUF_SIZE, "%s_%d", shm_name_prefix, i);
-            // printf("open %s, %d\n", shm_name, rank);
-            do {
-                shared_open(&allreduce_buffer, shm_name, sizeof(struct allreduce_workspace));
-            } while (allreduce_buffer.descriptor == -1 && errno == ENOENT);
-            workspace_buf_other = (struct allreduce_workspace*)allreduce_buffer.bytes;
-            workspace[i] = workspace_buf_other;
-        } else {
-            workspace[i] = workspace_buf;
-        }
-        symmetric_buffer[0][i] = workspace[i]->buffer + BUFFER0_OFFSET(0);
-        symmetric_buffer[1][i] = workspace[i]->buffer + BUFFER0_OFFSET(1);
-        distributed_buffer[0][i] = workspace[i]->buffer + BUFFER1_OFFSET(0);
-        distributed_buffer[1][i] = workspace[i]->buffer + BUFFER1_OFFSET(1);
+  // map shm of all ranks
+  for (int i = 0; i < size; i++) {
+    if (i != rank) {
+      snprintf(shm_name, NAME_BUF_SIZE, "%s_%d", shm_name_prefix, i);
+      // printf("open %s, %d\n", shm_name, rank);
+      do {
+        shared_open(
+            &allreduce_buffer, shm_name, sizeof(struct allreduce_workspace));
+      } while (allreduce_buffer.descriptor == -1 && errno == ENOENT);
+      workspace_buf_other = (struct allreduce_workspace*)allreduce_buffer.bytes;
+      workspace[i] = workspace_buf_other;
+    } else {
+      workspace[i] = workspace_buf;
     }
+    symmetric_buffer[0][i] = workspace[i]->buffer + BUFFER0_OFFSET(0);
+    symmetric_buffer[1][i] = workspace[i]->buffer + BUFFER0_OFFSET(1);
+    distributed_buffer[0][i] = workspace[i]->buffer + BUFFER1_OFFSET(0);
+    distributed_buffer[1][i] = workspace[i]->buffer + BUFFER1_OFFSET(1);
+  }
 }
 
 static void parallel_memcpy(void* to, void* from, size_t n_bytes)
     __attribute__((target("avx512bw")));
-static void parallel_memcpy(void* to, void* from, size_t n_bytes)
-{
-    auto aligned_bytes = n_bytes - (n_bytes % VECTOR_LENGTH_IN_BYTES);
-    // process aligned part
+static void parallel_memcpy(void* to, void* from, size_t n_bytes) {
+  auto aligned_bytes = n_bytes - (n_bytes % VECTOR_LENGTH_IN_BYTES);
+  // process aligned part
 #pragma omp parallel for
-    for (int i = 0; i < aligned_bytes; i += VECTOR_LENGTH_IN_BYTES) {
-        auto val = _mm256_loadu_si256((__m256i*)((char*)from + i));
-        _mm256_storeu_si256((__m256i*)((char*)to + i), val);
-    }
+  for (int i = 0; i < aligned_bytes; i += VECTOR_LENGTH_IN_BYTES) {
+    auto val = _mm256_loadu_si256((__m256i*)((char*)from + i));
+    _mm256_storeu_si256((__m256i*)((char*)to + i), val);
+  }
 
-    // process remaining part
-    for (int i = aligned_bytes; i < n_bytes; i++) { *((char*)to + i) = *((char*)from + i); }
+  // process remaining part
+  for (int i = aligned_bytes; i < n_bytes; i++) {
+    *((char*)to + i) = *((char*)from + i);
+  }
 }
 
 #define positive_mod(num, mod) ((((num) % (mod)) + (mod)) % (mod))
 #define rank_mod(rank) positive_mod(rank, world_size)
-size_t slice_size(size_t chunk_el, int slice_idx)
-{
-    size_t slice_size = chunk_el / world_size;
-    return slice_idx == world_size - 1 ? slice_size + (chunk_el % world_size) : slice_size;
+size_t slice_size(size_t chunk_el, int slice_idx) {
+  size_t slice_size = chunk_el / world_size;
+  return slice_idx == world_size - 1 ? slice_size + (chunk_el % world_size)
+                                     : slice_size;
 }
 
-char* slice_data(char* data_ptr, size_t chunk_el, int el_size, int slice_idx)
-{
-    size_t slice_size = chunk_el / world_size;
-    size_t el_offset = slice_size * slice_idx;
-    return data_ptr + el_offset * el_size;
+char* slice_data(char* data_ptr, size_t chunk_el, int el_size, int slice_idx) {
+  size_t slice_size = chunk_el / world_size;
+  size_t el_offset = slice_size * slice_idx;
+  return data_ptr + el_offset * el_size;
 }
 
-size_t slice_el_start(size_t chunk_el, int slice_idx)
-{
-    size_t slice_size = chunk_el / world_size;
-    return slice_size * slice_idx;
+size_t slice_el_start(size_t chunk_el, int slice_idx) {
+  size_t slice_size = chunk_el / world_size;
+  return slice_size * slice_idx;
 }
 
-void symmetric_naive_all_reduce(char* data_ptr,
-                                c10::ScalarType scalar_type,
-                                size_t chunk_size,
-                                size_t chunk_el)
-{
-    const int state_group = 0;
-    static int current_buffer = 0;
-    static int state_idx = 0;
+void symmetric_naive_all_reduce(
+    char* data_ptr,
+    c10::ScalarType scalar_type,
+    size_t chunk_size,
+    size_t chunk_el) {
+  const int state_group = 0;
+  static int current_buffer = 0;
+  static int state_idx = 0;
 
-    enum coll_state copy_current, copy_next;
+  enum coll_state copy_current, copy_next;
 
-    switch (state_idx) {
-        case 0:
-            copy_current = coll_allreduce_naive__copy_in_done;
-            copy_next = coll_alt1_allreduce_naive__copy_in_done;
-            break;
-        case 1:
-            copy_current = coll_alt1_allreduce_naive__copy_in_done;
-            copy_next = coll_alt2_allreduce_naive__copy_in_done;
-            break;
-        case 2:
-            copy_current = coll_alt2_allreduce_naive__copy_in_done;
-            copy_next = coll_allreduce_naive__copy_in_done;
-            break;
-        default: assert(!"Should not get here.");
+  switch (state_idx) {
+    case 0:
+      copy_current = coll_allreduce_naive__copy_in_done;
+      copy_next = coll_alt1_allreduce_naive__copy_in_done;
+      break;
+    case 1:
+      copy_current = coll_alt1_allreduce_naive__copy_in_done;
+      copy_next = coll_alt2_allreduce_naive__copy_in_done;
+      break;
+    case 2:
+      copy_current = coll_alt2_allreduce_naive__copy_in_done;
+      copy_next = coll_allreduce_naive__copy_in_done;
+      break;
+    default:
+      assert(!"Should not get here.");
+  }
+  state_idx = (state_idx + 1) % 3;
+
+  parallel_memcpy(
+      symmetric_buffer[current_buffer][world_rank], data_ptr, chunk_size);
+  std::atomic_thread_fence(std::memory_order_release);
+  workspace[world_rank]->states[state_group] = copy_current;
+
+  for (int i = 0; i < world_size; i++) {
+    // wait until the other rank copy the buffer
+    if (i != world_rank) {
+      wait_buffer_state_until_2(i, copy_current, copy_next, state_group);
     }
-    state_idx = (state_idx + 1) % 3;
+  }
 
-    parallel_memcpy(symmetric_buffer[current_buffer][world_rank], data_ptr, chunk_size);
-    std::atomic_thread_fence(std::memory_order_release);
-    workspace[world_rank]->states[state_group] = copy_current;
+  // each rank reduce the buffer independently so therre is no need for
+  // synchronization afterward
+  reduce_all_buffers(
+      0,
+      chunk_el,
+      scalar_type,
+      world_rank,
+      data_ptr,
+      symmetric_buffer[current_buffer]);
 
-    for (int i = 0; i < world_size; i++) {
-        // wait until the other rank copy the buffer
-        if (i != world_rank) { wait_buffer_state_until_2(i, copy_current, copy_next, state_group); }
-    }
-
-    // each rank reduce the buffer independently so therre is no need for synchronization afterward
-    reduce_all_buffers(
-        0, chunk_el, scalar_type, world_rank, data_ptr, symmetric_buffer[current_buffer]);
-
-    // switch buffer
-    current_buffer = 1 - current_buffer;
+  // switch buffer
+  current_buffer = 1 - current_buffer;
 }
 
 // naive allreduce distributed, each rank do naive reduce on its slice
-void distributed_naive_reduce(char* data_ptr,
-                              c10::ScalarType scalar_type,
-                              size_t chunk_size,
-                              size_t chunk_el)
-{
-    const int state_group = 1;
-    static int current_buffer = 0;
-    static int state_idx = 0;
+void distributed_naive_reduce(
+    char* data_ptr,
+    c10::ScalarType scalar_type,
+    size_t chunk_size,
+    size_t chunk_el) {
+  const int state_group = 1;
+  static int current_buffer = 0;
+  static int state_idx = 0;
 
-    enum coll_state copy_current, copy_next, reduce_current;
+  enum coll_state copy_current, copy_next, reduce_current;
 
-    // similar to symmetric_naive_allreduce, but here we only need two sets of
-    // states, because distributed naive reduce has two barriers in the algorithm
-    switch (state_idx) {
-        case 0:
-            copy_current = coll_allreduce_naive__copy_in_done;
-            reduce_current = coll_allreduce_naive__reduce_done;
-            copy_next = coll_alt1_allreduce_naive__copy_in_done;
-            break;
-        case 1:
-            copy_current = coll_alt1_allreduce_naive__copy_in_done;
-            reduce_current = coll_alt1_allreduce_naive__reduce_done;
-            copy_next = coll_allreduce_naive__copy_in_done;
-            break;
-        default: assert(!"Should not get here.");
-    }
-    state_idx = (state_idx + 1) % 2;
+  // similar to symmetric_naive_allreduce, but here we only need two sets of
+  // states, because distributed naive reduce has two barriers in the algorithm
+  switch (state_idx) {
+    case 0:
+      copy_current = coll_allreduce_naive__copy_in_done;
+      reduce_current = coll_allreduce_naive__reduce_done;
+      copy_next = coll_alt1_allreduce_naive__copy_in_done;
+      break;
+    case 1:
+      copy_current = coll_alt1_allreduce_naive__copy_in_done;
+      reduce_current = coll_alt1_allreduce_naive__reduce_done;
+      copy_next = coll_allreduce_naive__copy_in_done;
+      break;
+    default:
+      assert(!"Should not get here.");
+  }
+  state_idx = (state_idx + 1) % 2;
 
-    int data_size = chunk_size / chunk_el;
-    parallel_memcpy(distributed_buffer[current_buffer][world_rank], data_ptr, chunk_size);
-    std::atomic_thread_fence(std::memory_order_release);
-    workspace[world_rank]->states[state_group] = copy_current;
+  int data_size = chunk_size / chunk_el;
+  parallel_memcpy(
+      distributed_buffer[current_buffer][world_rank], data_ptr, chunk_size);
+  std::atomic_thread_fence(std::memory_order_release);
+  workspace[world_rank]->states[state_group] = copy_current;
 
-    for (int i = 0; i < world_size; i++) {
-        // wait until all the other ranks copy the buffer
-        if (i != world_rank)
-            wait_buffer_state_until_2(i, copy_current, reduce_current, state_group);
-    }
+  for (int i = 0; i < world_size; i++) {
+    // wait until all the other ranks copy the buffer
+    if (i != world_rank)
+      wait_buffer_state_until_2(i, copy_current, reduce_current, state_group);
+  }
 
-    // reduce scatter
-    reduce_all_buffers(slice_el_start(chunk_el, world_rank),
-                       slice_size(chunk_el, world_rank),
-                       scalar_type,
-                       world_rank,
-                       distributed_buffer[current_buffer][world_rank],
-                       distributed_buffer[current_buffer]);
-    std::atomic_thread_fence(std::memory_order_release);
-    workspace[world_rank]->states[state_group] = reduce_current;
+  // reduce scatter
+  reduce_all_buffers(
+      slice_el_start(chunk_el, world_rank),
+      slice_size(chunk_el, world_rank),
+      scalar_type,
+      world_rank,
+      distributed_buffer[current_buffer][world_rank],
+      distributed_buffer[current_buffer]);
+  std::atomic_thread_fence(std::memory_order_release);
+  workspace[world_rank]->states[state_group] = reduce_current;
 
-    for (int i = 0; i < world_size; i++) {
-        // wait until all the other ranks reduce the buffer
-        if (i != world_rank) wait_buffer_state_until_2(i, reduce_current, copy_next, state_group);
-    }
+  for (int i = 0; i < world_size; i++) {
+    // wait until all the other ranks reduce the buffer
+    if (i != world_rank)
+      wait_buffer_state_until_2(i, reduce_current, copy_next, state_group);
+  }
 
-    auto t4 = std::chrono::system_clock::now();
+  auto t4 = std::chrono::system_clock::now();
 
-    for (int i = 0; i < world_size; i++) {
-        int rank = (i + world_rank) % world_size;
-        parallel_memcpy(
-            slice_data(data_ptr, chunk_el, data_size, rank),
-            slice_data(
-                distributed_buffer[current_buffer][rank], chunk_el, chunk_size / chunk_el, rank),
-            slice_size(chunk_el, rank) * data_size);
-    }
+  for (int i = 0; i < world_size; i++) {
+    int rank = (i + world_rank) % world_size;
+    parallel_memcpy(
+        slice_data(data_ptr, chunk_el, data_size, rank),
+        slice_data(
+            distributed_buffer[current_buffer][rank],
+            chunk_el,
+            chunk_size / chunk_el,
+            rank),
+        slice_size(chunk_el, rank) * data_size);
+  }
 
-    current_buffer = 1 - current_buffer;
+  current_buffer = 1 - current_buffer;
 }
 
-void all_reduce_outer_loop(torch::Tensor& data, size_t numel, int data_size)
-{
-    for (int offset = 0; offset < data_size; offset += MAX_BUF_SIZE) {
-        auto data_ptr = ((char*)(data.data_ptr()) + offset);
-        size_t chunk_size = data_size - offset > MAX_BUF_SIZE ? MAX_BUF_SIZE : data_size - offset;
-        size_t chunk_el = chunk_size / (data_size / numel);
-        if (chunk_size < NAIVE_ALLREDUCE_THRESHOLD) {
-            symmetric_naive_all_reduce(data_ptr, data.scalar_type(), chunk_size, chunk_el);
-        }
-        else {
-            distributed_naive_reduce(data_ptr, data.scalar_type(), chunk_size, chunk_el);
-        }
+void all_reduce_outer_loop(torch::Tensor& data, size_t numel, int data_size) {
+  for (int offset = 0; offset < data_size; offset += MAX_BUF_SIZE) {
+    auto data_ptr = ((char*)(data.data_ptr()) + offset);
+    size_t chunk_size =
+        data_size - offset > MAX_BUF_SIZE ? MAX_BUF_SIZE : data_size - offset;
+    size_t chunk_el = chunk_size / (data_size / numel);
+    if (chunk_size < NAIVE_ALLREDUCE_THRESHOLD) {
+      symmetric_naive_all_reduce(
+          data_ptr, data.scalar_type(), chunk_size, chunk_el);
+    } else {
+      distributed_naive_reduce(
+          data_ptr, data.scalar_type(), chunk_size, chunk_el);
     }
+  }
 }

--- a/sgl-kernel/src/sgl-kernel/csrc/cpu/shm.h
+++ b/sgl-kernel/src/sgl-kernel/csrc/cpu/shm.h
@@ -1,0 +1,9 @@
+#include <torch/torch.h>
+#include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
+
+#ifndef __SHM_COLLECTIVES__
+#define __SHM_COLLECTIVES__
+#define VECTOR_LENGTH_IN_BYTES 32
+void shm_initialize(int size, int rank, char* addr_string, char* port_string);
+void all_reduce_outer_loop(torch::Tensor& data, size_t numel, int data_size);
+#endif

--- a/sgl-kernel/src/sgl-kernel/csrc/cpu/shm.h
+++ b/sgl-kernel/src/sgl-kernel/csrc/cpu/shm.h
@@ -1,5 +1,5 @@
-#include <torch/torch.h>
 #include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
+#include <torch/torch.h>
 
 #ifndef __SHM_COLLECTIVES__
 #define __SHM_COLLECTIVES__

--- a/sgl-kernel/src/sgl-kernel/ops/__init__.py
+++ b/sgl-kernel/src/sgl-kernel/ops/__init__.py
@@ -1,15 +1,20 @@
-from sgl_kernel.ops._kernels import all_reduce as _all_reduce
-from sgl_kernel.ops._kernels import dispose as _dispose
-from sgl_kernel.ops._kernels import (
-    get_graph_buffer_ipc_meta as _get_graph_buffer_ipc_meta,
-)
-from sgl_kernel.ops._kernels import init_custom_ar as _init_custom_ar
-from sgl_kernel.ops._kernels import int8_scaled_mm as _int8_scaled_mm
-from sgl_kernel.ops._kernels import moe_align_block_size as _moe_align_block_size
-from sgl_kernel.ops._kernels import register_graph_buffers as _register_graph_buffers
-from sgl_kernel.ops._kernels import (
-    sampling_scaling_penalties as _sampling_scaling_penalties,
-)
+import torch
+
+if torch.cuda.is_available():
+    from sgl_kernel.ops._kernels import all_reduce as _all_reduce
+    from sgl_kernel.ops._kernels import dispose as _dispose
+    from sgl_kernel.ops._kernels import (
+        get_graph_buffer_ipc_meta as _get_graph_buffer_ipc_meta,
+    )
+    from sgl_kernel.ops._kernels import init_custom_ar as _init_custom_ar
+    from sgl_kernel.ops._kernels import int8_scaled_mm as _int8_scaled_mm
+    from sgl_kernel.ops._kernels import moe_align_block_size as _moe_align_block_size
+    from sgl_kernel.ops._kernels import (
+        register_graph_buffers as _register_graph_buffers,
+    )
+    from sgl_kernel.ops._kernels import (
+        sampling_scaling_penalties as _sampling_scaling_penalties,
+    )
 
 
 def init_custom_reduce(


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Optimize `all_reduce` by porting the shared memory implementation in deepspeed.


## Modifications

1. We added a `shm_allreduce` operator in `sgl-kernel`.

    The implementation is ported from DeepSpeed:
    `sgl-kernel/src/sgl-kernel/csrc/cpu/shm.h`   --->   [DeepSpeed: shm.h](https://github.com/deepspeedai/DeepSpeed/blob/14b3cce4aaedac69120d386953e2b4cae8c2cf2c/csrc/cpu/comm/shm.h)
    `sgl-kernel/src/sgl-kernel/csrc/cpu/shm.cpp`   --->   [DeepSpeed: shm.cpp](https://github.com/deepspeedai/DeepSpeed/blob/14b3cce4aaedac69120d386953e2b4cae8c2cf2c/csrc/cpu/comm/shm.cpp)
    `sgl-kernel/src/sgl-kernel/csrc/cpu/interface.cpp`   --->   [DeepSpeed: ccl.cpp](https://github.com/deepspeedai/DeepSpeed/blob/14b3cce4aaedac69120d386953e2b4cae8c2cf2c/csrc/cpu/comm/ccl.cpp)
    
    To build the kernel:
    ```sh
    cd sgl-kernel
    python setup.py develop
    ```

2. We added a wrapper call `tensor_model_parallel_all_reduce_wrapper` in SGLang to call the `shm_allreduce` for CPU and call the original `tensor_model_parallel_all_reduce` API in vllm for other devices, so that we don't need to change the `tensor_model_parallel_all_reduce` function in vllm.

3. In `sgl-kernel/src/sgl-kernel/ops/__init__.py`, we only import cuda kernels if cuda is available.


## Benchmarks
### Accuracy
The score on mmlu (higher is better) for tp=2:
**score without this PR (using torch.distributed.all_reduce)**: 0.594
**score with this PR**: 0.594

**Note**: `--disable-overlap-schedule` is needed in the args for CPU, otherwise, a new thread will be created for the forward batch [here](https://github.com/sgl-project/sglang/blob/522e18eaebc2f14135249bf95f24ce3505683082/python/sglang/srt/managers/tp_worker_overlap_thread.py#L79-L81) and the OMP threads binding will not work on this newly created thread.

Command line:
```sh
# Server side
# tp = 2:
SGLANG_CPU_OMP_THREADS_BIND="0-39|40-79" python3 -m sglang.launch_server --model deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct --disable-radix --trust-remote-code --device cpu --attention-backend torch_native --disable-mla --log-requests --disable-overlap-schedule --tp 2
```

```sh
# Client side
python3 -m sglang.test.run_eval --eval-name mmlu --num-examples 64 --port 30000
```

### Performance
We can observe 25% and 37% speedup on first and next token latency respectively after switching from `torch.distributed.all_reduce` to `shm_allreduce` for the below tp=2 command line on GNR.

```sh
SGLANG_CPU_OMP_THREADS_BIND="0-39|40-79" python3 -m sglang.bench_one_batch --batch-size 1 --input 1024 --output 8 --model deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct --trust-remote-code --device cpu --attention-backend torch_native --disable-mla --tp 2
```


## Limitations
The shm `all_reduce` only supports FP32 and BF16 and the cases where all the ranks are local. We fallback to `torch.distributed.all_reduce` for unsupported cases.


