### PR TITLE
Support the case where `num_attention_heads` is not divisible by the TP size

### DIFF
--- a/python/sglang/srt/cpu_utils.py
+++ b/python/sglang/srt/cpu_utils.py
@@ -1,4 +1,10 @@
-from sglang.srt.configs.model_config import ModelConfig
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sglang.srt.configs.model_config import ModelConfig
+
 from sglang.srt.layers.vocab_parallel_embedding import pad_vocab_size
 
 DEFAULT_MOE_PADDING_SIZE = 32
@@ -33,3 +39,13 @@ def update_config(model_config: ModelConfig, tp_size: int) -> ModelConfig:
 
 def get_actual_shard_size(shard_size, weight_start, weight_end):
     return min(shard_size, weight_end - weight_start)
+
+
+def reset_param_data_if_needed(param_data, dim, start, length):
+    if length == 0:
+        return
+
+    assert length > 0, f"Length should be positive, but got {length}"
+
+    param_data.narrow(dim, start, length).zero_()
+    return

--- a/python/sglang/srt/cpu_utils.py
+++ b/python/sglang/srt/cpu_utils.py
@@ -1,0 +1,35 @@
+from sglang.srt.configs.model_config import ModelConfig
+from sglang.srt.layers.vocab_parallel_embedding import pad_vocab_size
+
+DEFAULT_MOE_PADDING_SIZE = 32
+
+
+def update_config(model_config: ModelConfig, tp_size: int) -> ModelConfig:
+    # Support the case where the num_attention_heads is not divisible by the TP size.
+    if model_config.num_attention_heads % tp_size != 0:
+        query_heads_per_kv = (
+            model_config.num_attention_heads // model_config.get_total_num_kv_heads()
+        )
+        total_kv_heads = model_config.get_total_num_kv_heads()
+        num_key_value_heads = pad_vocab_size(total_kv_heads, tp_size)
+        model_config.num_key_value_heads = num_key_value_heads
+        model_config.hf_config.num_key_value_heads = num_key_value_heads
+        model_config.hf_text_config.num_key_value_heads = num_key_value_heads
+
+        num_attention_heads = num_key_value_heads * query_heads_per_kv
+        model_config.num_attention_heads = num_attention_heads
+        model_config.hf_config.num_attention_heads = num_attention_heads
+        model_config.hf_text_config.num_attention_heads = num_attention_heads
+
+        moe_intermediate_size = model_config.hf_config.moe_intermediate_size
+        moe_intermediate_size = pad_vocab_size(
+            moe_intermediate_size, tp_size * DEFAULT_MOE_PADDING_SIZE
+        )
+        model_config.hf_config.moe_intermediate_size = moe_intermediate_size
+        model_config.hf_text_config.moe_intermediate_size = moe_intermediate_size
+
+    return model_config
+
+
+def get_actual_shard_size(shard_size, weight_start, weight_end):
+    return min(shard_size, weight_end - weight_start)

--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -28,7 +28,7 @@ from sglang.srt.layers.quantization.base_config import (
     QuantizeMethodBase,
 )
 from sglang.srt.layers.quantization.fp8_utils import BlockQuantScaleParameter
-from sglang.srt.utils import get_actual_shard_size, set_weight_attrs
+from sglang.srt.utils import set_weight_attrs
 
 logger = logging.getLogger(__name__)
 
@@ -404,6 +404,8 @@ class ColumnParallelLinear(LinearBase):
         if output_dim is not None and not use_bitsandbytes_4bit:
             shard_size = param_data.shape[output_dim]
             start_idx = self.tp_rank * shard_size
+            from sglang.srt.cpu_utils import get_actual_shard_size
+
             actual_shard_size = get_actual_shard_size(
                 shard_size, start_idx, loaded_weight.size(output_dim)
             )
@@ -618,6 +620,8 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
 
             param_data = param_data.narrow(output_dim, shard_offset, shard_size)
             start_idx = self.tp_rank * shard_size
+            from sglang.srt.cpu_utils import get_actual_shard_size
+
             actual_shard_size = get_actual_shard_size(
                 shard_size, start_idx, loaded_weight.size(output_dim)
             )
@@ -1226,6 +1230,8 @@ class RowParallelLinear(LinearBase):
         ):
             shard_size = param_data.shape[input_dim]
             start_idx = self.tp_rank * shard_size
+            from sglang.srt.cpu_utils import get_actual_shard_size
+
             actual_shard_size = get_actual_shard_size(
                 shard_size, start_idx, loaded_weight.size(input_dim)
             )

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -6,6 +6,7 @@ from typing import Callable, List, Optional, Tuple
 
 import torch
 
+from sglang.srt.cpu_utils import get_actual_shard_size
 from sglang.srt.custom_op import CustomOp
 from sglang.srt.distributed import (
     get_tensor_model_parallel_rank,
@@ -18,13 +19,7 @@ from sglang.srt.layers.quantization.base_config import (
     QuantizationConfig,
     QuantizeMethodBase,
 )
-from sglang.srt.utils import (
-    get_actual_shard_size,
-    get_bool_env_var,
-    is_hip,
-    permute_weight,
-    set_weight_attrs,
-)
+from sglang.srt.utils import get_bool_env_var, is_hip, permute_weight, set_weight_attrs
 
 if torch.cuda.is_available():
     from sglang.srt.layers.moe.fused_moe_triton.fused_moe import fused_experts

--- a/python/sglang/srt/layers/vocab_parallel_embedding.py
+++ b/python/sglang/srt/layers/vocab_parallel_embedding.py
@@ -234,8 +234,13 @@ class VocabParallelEmbedding(torch.nn.Module):
             self.tp_size = 1
 
         self.num_embeddings = num_embeddings
-        self.padding_size = padding_size
         self.org_vocab_size = org_num_embeddings or num_embeddings
+
+        # Support the case where the vocab size is not divisible by the TP size.
+        if pad_vocab_size(self.org_vocab_size, padding_size) % self.tp_size != 0:
+            padding_size *= self.tp_size
+        self.padding_size = padding_size
+
         num_added_embeddings = num_embeddings - self.org_vocab_size
         self.use_presharded_weights = use_presharded_weights
         if use_presharded_weights:

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -72,7 +72,6 @@ from sglang.srt.utils import (
     set_cuda_arch,
 )
 
-# TODO: why using 8?
 DEFAULT_MOE_PADDING_SIZE = 8
 
 logger = logging.getLogger(__name__)

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -45,7 +45,6 @@ from sglang.srt.layers.dp_attention import (
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.layers.sampler import Sampler
 from sglang.srt.layers.torchao_utils import apply_torchao_config_to_model
-from sglang.srt.layers.vocab_parallel_embedding import pad_vocab_size
 from sglang.srt.lora.lora_manager import LoRAManager
 from sglang.srt.managers.schedule_batch import global_server_args_dict
 from sglang.srt.mem_cache.memory_pool import (
@@ -72,8 +71,6 @@ from sglang.srt.utils import (
     set_cuda_arch,
 )
 
-DEFAULT_MOE_PADDING_SIZE = 8
-
 logger = logging.getLogger(__name__)
 
 
@@ -97,7 +94,13 @@ class ModelRunner:
         self.gpu_id = gpu_id
         self.tp_rank = tp_rank
         self.tp_size = tp_size
-        self.model_config = self.update_config(model_config)
+
+        from sglang.srt.cpu_utils import update_config
+
+        if self.device == "cpu":
+            model_config = update_config(model_config, self.tp_size)
+
+        self.model_config = model_config
         self.dist_port = nccl_port
         self.server_args = server_args
         self.is_draft_worker = is_draft_worker
@@ -236,33 +239,6 @@ class ModelRunner:
         else:
             self.cuda_graph_runner = None
             self.init_attention_backend()
-
-    def update_config(self, model_config: ModelConfig) -> ModelConfig:
-        # Support the case where the num_attention_heads is not divisible by the TP size.
-        if model_config.num_attention_heads % self.tp_size != 0:
-            query_heads_per_kv = (
-                model_config.num_attention_heads
-                // model_config.get_total_num_kv_heads()
-            )
-            total_kv_heads = model_config.get_total_num_kv_heads()
-            num_key_value_heads = pad_vocab_size(total_kv_heads, self.tp_size)
-            model_config.num_key_value_heads = num_key_value_heads
-            model_config.hf_config.num_key_value_heads = num_key_value_heads
-            model_config.hf_text_config.num_key_value_heads = num_key_value_heads
-
-            num_attention_heads = num_key_value_heads * query_heads_per_kv
-            model_config.num_attention_heads = num_attention_heads
-            model_config.hf_config.num_attention_heads = num_attention_heads
-            model_config.hf_text_config.num_attention_heads = num_attention_heads
-
-            moe_intermediate_size = model_config.hf_config.moe_intermediate_size
-            moe_intermediate_size = pad_vocab_size(
-                moe_intermediate_size, self.tp_size * DEFAULT_MOE_PADDING_SIZE
-            )
-            model_config.hf_config.moe_intermediate_size = moe_intermediate_size
-            model_config.hf_text_config.moe_intermediate_size = moe_intermediate_size
-
-        return model_config
 
     def init_torch_distributed(self):
         logger.info("Init torch distributed begin.")

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -26,6 +26,7 @@ import torch.distributed as dist
 from sglang.srt.configs.device_config import DeviceConfig
 from sglang.srt.configs.load_config import LoadConfig
 from sglang.srt.configs.model_config import AttentionArch, ModelConfig
+from sglang.srt.cpu_utils import update_config
 from sglang.srt.distributed import (
     get_tp_group,
     init_distributed_environment,
@@ -94,12 +95,8 @@ class ModelRunner:
         self.gpu_id = gpu_id
         self.tp_rank = tp_rank
         self.tp_size = tp_size
-
-        from sglang.srt.cpu_utils import update_config
-
         if self.device == "cpu":
             model_config = update_config(model_config, self.tp_size)
-
         self.model_config = model_config
         self.dist_port = nccl_port
         self.server_args = server_args

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -1451,7 +1451,3 @@ def set_cuda_arch():
         capability = torch.cuda.get_device_capability()
         arch = f"{capability[0]}.{capability[1]}"
         os.environ["TORCH_CUDA_ARCH_LIST"] = f"{arch}{'+PTX' if arch == '9.0' else ''}"
-
-
-def get_actual_shard_size(shard_size, weight_start, weight_end):
-    return min(shard_size, weight_end - weight_start)

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -1451,3 +1451,7 @@ def set_cuda_arch():
         capability = torch.cuda.get_device_capability()
         arch = f"{capability[0]}.{capability[1]}"
         os.environ["TORCH_CUDA_ARCH_LIST"] = f"{arch}{'+PTX' if arch == '9.0' else ''}"
+
+
+def get_actual_shard_size(shard_size, weight_start, weight_end):
+    return min(shard_size, weight_end - weight_start)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Support the case where the `num_attention_heads` is not divisible by the TP size, for example for `num_attention_heads` = 16 and TP = 3 or TP = 6 on GNR.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications
- We will pad `num_attention_heads`, `moe_intermediate_size`, `vocab_size` and update the `config` so that they're divisible by the TP size.
- When loading the weights, we will initialize the value of the weight param (which might have been padded) to zero (so that the padded value won't have impact on the final result). We then narrow the weight param to their actual size (before the padding) and copy the loaded real weight value into these param.

## Example
The below commands using TP = 6 work now:
### Offline:
```sh
SGLANG_CPU_OMP_THREADS_BIND="0-39|40-79|80-119|120-159|160-199|200-239" python3 -m sglang.bench_one_batch --batch-size 1 --input 1024 --output 8 --model deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct --trust-remote-code --device cpu --attention-backend torch_native --disable-mla --tp 6
```

### Server:
```sh
SGLANG_CPU_OMP_THREADS_BIND="0-39|40-79|80-119|120-159|160-199|200-239" python3 -m sglang.launch_server --model deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct --disable-radix --trust-remote-code --device cpu --attention-backend torch_native --disable-mla --log-requests --disable-overlap-schedule --tp 6
```


<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [ ] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [ ] Update documentation as needed, including docstrings or example tutorials.
