### PR TITLE
switch to weight_packed_linear if cpu_has_amx_support

### DIFF
--- a/sgl-kernel/src/sgl-kernel/cpu.py
+++ b/sgl-kernel/src/sgl-kernel/cpu.py
@@ -84,3 +84,17 @@ def extend_attention(
         sm_scale,
         logit_cap,
     )
+
+
+def weight_packed_linear(
+    x,
+    weight,
+    bias,
+    is_vnni=True,
+):
+    return sgl_kernel.ops._kernels.weight_packed_linear(
+        x,
+        weight,
+        bias,
+        is_vnni,
+    )


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Switch to weight_packed_linear if cpu_has_amx_support.
## Modifications

<!-- Describe the changes made in this PR. -->
If cpu_has_amx_support and the weight tensor is on CPU, we will pack the weight and use `sgl_kernel.cpu.weight_packed_linear` for the computation. Otherwise, weight won't be packed and `F.linear` will be used.

## Checklist

- [ ] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [ ] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [ ] Update documentation as needed, including docstrings or example tutorials.
