### PR TITLE
support W8A8 for DeepSeek-R1 on CPU

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -10,7 +10,6 @@ from sglang.srt.cpu_utils import (
     _process_weight_after_loading,
     cpu_has_amx_support,
     get_actual_shard_size,
-    prepack_weight_if_needed,
     reset_param_data_if_needed,
 )
 from sglang.srt.custom_op import CustomOp

--- a/python/sglang/srt/layers/quantization/w8a8_int8.py
+++ b/python/sglang/srt/layers/quantization/w8a8_int8.py
@@ -10,6 +10,7 @@ if is_cuda:
 
 from torch.nn.parameter import Parameter
 
+from sglang.srt.cpu_utils import _process_weight_after_loading, cpu_has_amx_support
 from sglang.srt.distributed import get_tensor_model_parallel_world_size
 from sglang.srt.layers.linear import LinearMethodBase
 from sglang.srt.layers.parameter import ChannelQuantScaleParameter, ModelWeightParameter
@@ -18,6 +19,9 @@ from sglang.srt.layers.quantization.base_config import (
     QuantizeMethodBase,
 )
 from sglang.srt.layers.quantization.int8_kernel import per_token_quant_int8
+
+if cpu_has_amx_support():
+    import sgl_kernel.cpu
 
 
 class W8A8Int8Config(QuantizationConfig):
@@ -74,6 +78,10 @@ class W8A8Int8LinearMethod(LinearMethodBase):
         self.quantization_config = quantization_config
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if layer.weight.device == torch.device("cpu"):
+            _process_weight_after_loading(layer, ["weight"])
+            return
+
         layer.weight = Parameter(layer.weight.t(), requires_grad=False)
         layer.weight_scale = Parameter(layer.weight_scale.data, requires_grad=False)
 
@@ -114,6 +122,12 @@ class W8A8Int8LinearMethod(LinearMethodBase):
         x: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ):
+        if layer.use_intel_amx_backend:
+            x_q, x_scale = sgl_kernel.cpu.per_token_quant_int8(x)
+            return sgl_kernel.cpu.int8_scaled_mm(
+                x_q, layer.weight, x_scale, layer.weight_scale, bias, x.dtype
+            )
+
         x_q, x_scale = per_token_quant_int8(x)
 
         return int8_scaled_mm(
@@ -208,6 +222,12 @@ class W8A8Int8MoEMethod:
         layer.register_parameter("w2_input_scale", w2_input_scale)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if layer.w13_weight.device == torch.device(
+            "cpu"
+        ) and layer.w2_weight.device == torch.device("cpu"):
+            _process_weight_after_loading(layer, ["w13_weight", "w2_weight"])
+            return
+
         layer.w13_weight = Parameter(layer.w13_weight, requires_grad=False)
         layer.w2_weight = Parameter(layer.w2_weight, requires_grad=False)
         layer.w13_weight_scale = Parameter(
@@ -248,6 +268,21 @@ class W8A8Int8MoEMethod:
             custom_routing_function=custom_routing_function,
             correction_bias=correction_bias,
         )
+
+        if layer.use_intel_amx_backend:
+            return sgl_kernel.cpu.fused_experts(
+                x,
+                layer.w13_weight,
+                layer.w2_weight,
+                topk_weights,
+                topk_ids,
+                inplace=True,
+                use_int8_w8a8=True,
+                w1_scale=layer.w13_weight_scale,
+                w2_scale=layer.w2_weight_scale,
+                a1_scale=layer.w13_input_scale,
+                a2_scale=layer.w2_input_scale,
+            )
 
         return fused_experts(
             x,

--- a/python/sglang/srt/layers/quantization/w8a8_int8.py
+++ b/python/sglang/srt/layers/quantization/w8a8_int8.py
@@ -225,9 +225,7 @@ class W8A8Int8MoEMethod:
         layer.register_parameter("w2_input_scale", w2_input_scale)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        if layer.w13_weight.device == torch.device(
-            "cpu"
-        ) and layer.w2_weight.device == torch.device("cpu"):
+        if all(w.device.type == "cpu" for w in [layer.w13_weight, layer.w2_weight]):
             assert (
                 cpu_has_amx_support()
             ), "W8A8Int8MoEMethod on CPU requires that CPU has AMX support"

--- a/python/sglang/srt/layers/quantization/w8a8_int8.py
+++ b/python/sglang/srt/layers/quantization/w8a8_int8.py
@@ -79,6 +79,9 @@ class W8A8Int8LinearMethod(LinearMethodBase):
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         if layer.weight.device == torch.device("cpu"):
+            assert (
+                cpu_has_amx_support()
+            ), "W8A8Int8LinearMethod on CPU requires that CPU has AMX support"
             _process_weight_after_loading(layer, ["weight"])
             return
 
@@ -225,6 +228,9 @@ class W8A8Int8MoEMethod:
         if layer.w13_weight.device == torch.device(
             "cpu"
         ) and layer.w2_weight.device == torch.device("cpu"):
+            assert (
+                cpu_has_amx_support()
+            ), "W8A8Int8MoEMethod on CPU requires that CPU has AMX support"
             _process_weight_after_loading(layer, ["w13_weight", "w2_weight"])
             return
 

--- a/sgl-kernel/python/sgl_kernel/cpu.py
+++ b/sgl-kernel/python/sgl_kernel/cpu.py
@@ -9,6 +9,11 @@ def fused_experts(
     topk_weights,
     topk_ids,
     inplace,
+    use_int8_w8a8=False,
+    w1_scale=None,
+    w2_scale=None,
+    a1_scale=None,
+    a2_scale=None,
     is_vnni=True,
 ):
     return sgl_kernel.common_ops.fused_experts_cpu(
@@ -18,6 +23,11 @@ def fused_experts(
         topk_weights,
         topk_ids,
         inplace,
+        use_int8_w8a8,
+        w1_scale,
+        w2_scale,
+        a1_scale,
+        a2_scale,
         is_vnni,
     )
 
@@ -99,6 +109,7 @@ def weight_packed_linear(
         is_vnni,
     )
 
+
 def grouped_topk(
     topk_weights,
     topk_ids,
@@ -120,6 +131,7 @@ def grouped_topk(
         topk_group,
     )
 
+
 def fused_add_rmsnorm(
     input,
     residual,
@@ -133,6 +145,7 @@ def fused_add_rmsnorm(
         eps,
     )
 
+
 def rmsnorm(
     output,
     input,
@@ -145,3 +158,21 @@ def rmsnorm(
         weight,
         eps,
     )
+
+
+def int8_scaled_mm(
+    mat1,
+    mat2,
+    scales1,
+    scales2,
+    bias,
+    out_dtype,
+    is_vnni=True,
+):
+    return sgl_kernel.common_ops.int8_scaled_mm_cpu(
+        mat1, mat2, scales1, scales2, bias, out_dtype, is_vnni
+    )
+
+
+def per_token_quant_int8(x):
+    return sgl_kernel.common_ops.per_token_quant_int8_cpu(x)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Support W8A8 for DeepSeek-R1 on CPU.

If `use_intel_amx_backend`:
- for the `W8A8Int8MoEMethod`, we will pack weight and call `sgl_kernel.cpu.fused_experts`.
- for the `W8A8Int8LinearMethod`, we will pack weight and call `sgl_kernel.cpu.per_token_quant_int8`, `sgl_kernel.cpu.int8_scaled_mm`.

If the device is CPU but the CPU does not have AMX support, currently an assertion will be raised (we don't have a native implementation in this case).

<!-- Describe the changes made in this PR. -->
## Benchmarks
To run W8A8, please add `--quantization w8a8_int8` to the benchmark command and use this model: [meituan/DeepSeek-R1-Channel-INT8](https://huggingface.co/meituan/DeepSeek-R1-Channel-INT8)
```sh
SGLANG_CPU_OMP_THREADS_BIND="0-42|43-85|86-127|128-170|171-213|214-255" python3 -m sglang.bench_one_batch --batch-size 1 --input 1024 --output 8 --model meituan/DeepSeek-R1-Channel-INT8 --trust-remote-code --device cpu --quantization w8a8_int8 --tp 6
```
```sh
SGLANG_CPU_OMP_THREADS_BIND="0-42|43-85|86-127|128-170|171-213|214-255" python3 -m sglang.launch_server --model meituan/DeepSeek-R1-Channel-INT8 --disable-radix --trust-remote-code --device cpu --log-requests --log-requests-level 1 --disable-overlap-schedule --quantization w8a8_int8 --tp 6
```
