### PR TITLE
Replace torch.bmm in forward_absorb with sgl_kernel.cpu.bmm

### DIFF
--- a/python/sglang/srt/cpu_utils.py
+++ b/python/sglang/srt/cpu_utils.py
@@ -73,18 +73,28 @@ def prepack_weight_if_needed(weight):
     return convert_weight_packed(weight)
 
 
-def _process_weight_after_loading(module, weight_names) -> None:
+def _process_weight_after_loading(module, weight_names, transpose_dims=None) -> None:
     # Pack weight for get better performance on CPU
     devices = {getattr(module, weight_name).device for weight_name in weight_names}
     assert len(devices) == 1, f"Expects all weights to be on the same device"
     device = devices.pop()
 
-    for weight_name in weight_names:
+    if transpose_dims:
+        assert len(weight_names) == len(
+            transpose_dims
+        ), "len(weight_names) should be equal to len(transpose_dims)"
+
+    for i, weight_name in enumerate(weight_names):
+        weight_tensor = getattr(module, weight_name)
+        if transpose_dims:
+            transpose_dim = transpose_dims[i]
+            weight_tensor = weight_tensor.transpose(*transpose_dim)
+
         setattr(
             module,
             weight_name,
             torch.nn.Parameter(
-                prepack_weight_if_needed(getattr(module, weight_name)),
+                prepack_weight_if_needed(weight_tensor),
                 requires_grad=False,
             ),
         )
@@ -95,8 +105,9 @@ def _process_weight_after_loading(module, weight_names) -> None:
 
 
 class PackWeightMethod:
-    def __init__(self, weight_names):
+    def __init__(self, weight_names, transpose_dims=None):
         self.weight_names = weight_names
+        self.transpose_dims = transpose_dims
 
     def process_weights_after_loading(self, module) -> None:
-        _process_weight_after_loading(module, self.weight_names)
+        _process_weight_after_loading(module, self.weight_names, self.transpose_dims)

--- a/python/sglang/srt/cpu_utils.py
+++ b/python/sglang/srt/cpu_utils.py
@@ -86,9 +86,8 @@ def _process_weight_after_loading(module, weight_names, transpose_dims=None) -> 
 
     for i, weight_name in enumerate(weight_names):
         weight_tensor = getattr(module, weight_name)
-        if transpose_dims:
-            transpose_dim = transpose_dims[i]
-            weight_tensor = weight_tensor.transpose(*transpose_dim)
+        if transpose_dims and transpose_dims[i]:
+            weight_tensor = weight_tensor.transpose(*transpose_dims[i])
 
         setattr(
             module,

--- a/sgl-kernel/python/sgl_kernel/cpu.py
+++ b/sgl-kernel/python/sgl_kernel/cpu.py
@@ -201,6 +201,7 @@ def int8_scaled_mm(
 def per_token_quant_int8(x):
     return sgl_kernel.common_ops.per_token_quant_int8_cpu(x)
 
+
 def rotary_position_embedding(
     t_pos,
     q_pe,
@@ -214,6 +215,7 @@ def rotary_position_embedding(
         t_emb_pos,
     )
 
+
 def silu_and_mul(
     out,
     input,
@@ -222,3 +224,7 @@ def silu_and_mul(
         out,
         input,
     )
+
+
+def bmm(out, mat1, mat2, is_vnni=True, scale=None):
+    return sgl_kernel.common_ops.bmm_cpu(out, mat1, mat2, is_vnni, scale)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
If `use_intel_amx_backend`, replace `torch.bmm` in `forward_absorb` with `sgl_kernel.cpu.bmm`.

## Modifications
1. We need to convert the inputs to `torch.bmm` to align with the required shape format of `sgl_kernel.cpu.bmm`:
  - Shapes of inputs to bmm in the model:
      - `q_nope_out` (`out`): [B, M, N]
      - `q_nope` (`mat1`): [M, B, K]
      - original `self.w_kc`: [B, K, N]
      - current `self.w_kc` (`mat2`) (which has been converted in `PackWeightMethod`): [B, N, K]
  
  - Shapes of inputs to `sgl_kernel.cpu.bmm`:
      - `out`: [B, M, N]
      - `mat1`: [B, M, K]
      - `mat2`: [B, N, K]

2. Updated the `PackWeightMethod` to accept `transpose_dims` as an input and support transposing weight before weight pack.


<!-- Describe the changes made in this PR. -->
