### PR TITLE
Use shared_expert if use_intel_amx_backend and n_shared_experts is not None

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -253,7 +253,7 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
                 layer.w2_weight,
                 topk_weights,
                 topk_ids,
-                True,  # inplace
+                inplace=False, # See [Note] inplace should be False in fused_experts.
             )
         else:
             return moe_forward_native(

--- a/python/sglang/srt/layers/quantization/w8a8_int8.py
+++ b/python/sglang/srt/layers/quantization/w8a8_int8.py
@@ -280,7 +280,7 @@ class W8A8Int8MoEMethod:
                 layer.w2_weight,
                 topk_weights,
                 topk_ids,
-                inplace=True,
+                inplace=False, # See [Note] inplace should be False in fused_experts.
                 use_int8_w8a8=True,
                 w1_scale=layer.w13_weight_scale,
                 w2_scale=layer.w2_weight_scale,

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -201,16 +201,39 @@ class DeepseekV2MoE(nn.Module):
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         num_tokens, hidden_dim = hidden_states.shape
         hidden_states = hidden_states.view(-1, hidden_dim)
-        if self.n_shared_experts is not None:
-            shared_output = self.shared_experts(hidden_states)
+
         # router_logits: (num_tokens, n_experts)
         router_logits = self.gate(hidden_states)
-        final_hidden_states = (
-            self.experts(hidden_states=hidden_states, router_logits=router_logits)
-            * self.routed_scaling_factor
+        fused_experts_out = self.experts(
+            hidden_states=hidden_states, router_logits=router_logits
         )
-        if shared_output is not None:
-            final_hidden_states = final_hidden_states + shared_output
+
+        assert (
+            self.shared_experts.gate_up_proj.use_intel_amx_backend
+            == self.shared_experts.down_proj.use_intel_amx_backend
+        )
+        if (
+            self.n_shared_experts is not None
+            and self.shared_experts.gate_up_proj.use_intel_amx_backend
+        ):
+            # [Note] inplace should be False in fused_experts.
+            # If inplace is True in fused_experts (self.experts), hidden_states will be changed after fused_experts
+            # While hidden_states is still needed in shared_expert.
+            # TODO: where to add int8?
+            final_hidden_states = sgl_kernel.cpu.shared_expert(
+                hidden_states,
+                self.shared_experts.gate_up_proj.weight,
+                self.shared_experts.down_proj.weight,
+                fused_experts_out,
+                self.routed_scaling_factor,
+                inplace=True,
+            )
+        else:
+            if self.n_shared_experts is not None:
+                shared_output = self.shared_experts(hidden_states)
+            final_hidden_states = fused_experts_out * self.routed_scaling_factor
+            if shared_output is not None:
+                final_hidden_states = final_hidden_states + shared_output
         if self.tp_size > 1:
             final_hidden_states = tensor_model_parallel_all_reduce(final_hidden_states)
 

--- a/sgl-kernel/python/sgl_kernel/cpu.py
+++ b/sgl-kernel/python/sgl_kernel/cpu.py
@@ -32,6 +32,36 @@ def fused_experts(
     )
 
 
+def shared_expert(
+    hidden_states,
+    w1,
+    w2,
+    fused_experts_out,
+    routed_scaling_factor,
+    inplace,
+    use_int8_w8a8=False,
+    w1_scale=None,
+    w2_scale=None,
+    a1_scale=None,
+    a2_scale=None,
+    is_vnni=True,
+):
+    return sgl_kernel.common_ops.shared_expert_cpu(
+        hidden_states,
+        w1,
+        w2,
+        fused_experts_out,
+        routed_scaling_factor,
+        inplace,
+        use_int8_w8a8,
+        w1_scale,
+        w2_scale,
+        a1_scale,
+        a2_scale,
+        is_vnni,
+    )
+
+
 def convert_weight_packed(weight):
     return sgl_kernel.common_ops.convert_weight_packed(weight)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
If `use_intel_amx_backend` and `n_shared_experts` is not None, we will use the `shared_expert` kernel.


## Modifications

We need to set `inplace` to be `False` in `fused_experts` after switching to `shared_expert` kernel. Otherwise `fused_experts` will change the value of `hidden_states`.

Verified that `deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct` (BF16) and `meituan/DeepSeek-R1-Channel-INT8` (INT8) both generated good sentences using this PR.

<!-- Describe the changes made in this PR. -->
