### PR TITLE
Use int8_scaled_mm_with_quant

### DIFF
--- a/python/sglang/srt/layers/quantization/w8a8_int8.py
+++ b/python/sglang/srt/layers/quantization/w8a8_int8.py
@@ -126,9 +126,8 @@ class W8A8Int8LinearMethod(LinearMethodBase):
         bias: Optional[torch.Tensor] = None,
     ):
         if layer.use_intel_amx_backend:
-            x_q, x_scale = sgl_kernel.cpu.per_token_quant_int8(x)
-            return sgl_kernel.cpu.int8_scaled_mm(
-                x_q, layer.weight, x_scale, layer.weight_scale, bias, x.dtype
+            return sgl_kernel.cpu.int8_scaled_mm_with_quant(
+                x, layer.weight, layer.weight_scale, bias, x.dtype
             )
 
         x_q, x_scale = per_token_quant_int8(x)

--- a/sgl-kernel/python/sgl_kernel/cpu.py
+++ b/sgl-kernel/python/sgl_kernel/cpu.py
@@ -218,6 +218,19 @@ def int8_scaled_mm(
     )
 
 
+def int8_scaled_mm_with_quant(
+    mat1,
+    mat2,
+    scales2,
+    bias,
+    out_dtype,
+    is_vnni=True,
+):
+    return sgl_kernel.common_ops.int8_scaled_mm_with_quant(
+        mat1, mat2, scales2, bias, out_dtype, is_vnni
+    )
+
+
 def per_token_quant_int8(x):
     return sgl_kernel.common_ops.per_token_quant_int8_cpu(x)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->


## Modifications
For `W8A8Int8LinearMethod`:
Before this PR: `sgl_kernel.cpu.per_token_quant_int8` + `sgl_kernel.cpu.int8_scaled_mm`
After this PR: `sgl_kernel.cpu.int8_scaled_mm_with_quant`

Verified that the generated sentence is good after this PR:
`input: 'The capital city of France is'`
`output: ' Paris. Paris is located in the northern'`

<!-- Describe the changes made in this PR. -->

