### PR TITLE
Pad intermediate_size

### DIFF
--- a/python/sglang/srt/cpu_utils.py
+++ b/python/sglang/srt/cpu_utils.py
@@ -19,6 +19,18 @@ except:
     is_intel_amx_backend_available = False
 
 
+def update_intermediate_size(model_config, attr_name, intermediate_padding_size):
+    if hasattr(model_config.hf_config, attr_name):
+        attr_value = getattr(model_config.hf_config, attr_name)
+        if attr_value % intermediate_padding_size != 0:
+            attr_value = pad_vocab_size(
+                attr_value, intermediate_padding_size
+            )
+            setattr(model_config.hf_config, attr_name, attr_value)
+            setattr(model_config.hf_text_config, attr_name, attr_value)
+    return model_config
+
+
 def update_config(model_config: ModelConfig, tp_size: int) -> ModelConfig:
     # Support the case where the num_attention_heads is not divisible by the TP size.
     if model_config.num_attention_heads % tp_size != 0:
@@ -36,12 +48,9 @@ def update_config(model_config: ModelConfig, tp_size: int) -> ModelConfig:
         model_config.hf_config.num_attention_heads = num_attention_heads
         model_config.hf_text_config.num_attention_heads = num_attention_heads
 
-        moe_intermediate_size = model_config.hf_config.moe_intermediate_size
-        moe_intermediate_size = pad_vocab_size(
-            moe_intermediate_size, tp_size * DEFAULT_MOE_PADDING_SIZE
-        )
-        model_config.hf_config.moe_intermediate_size = moe_intermediate_size
-        model_config.hf_text_config.moe_intermediate_size = moe_intermediate_size
+    intermediate_padding_size = tp_size * DEFAULT_MOE_PADDING_SIZE
+    model_config = update_intermediate_size(model_config, "moe_intermediate_size", intermediate_padding_size)
+    model_config = update_intermediate_size(model_config, "intermediate_size", intermediate_padding_size)
 
     return model_config
 


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Fixes TP=4 for DeepSeek V2 Lite.
Pad `intermediate_size` if intermediate_size can't be divided evenly by `tp_size * DEFAULT_MOE_PADDING_SIZE`.

Previously only `moe_intermediate_size` was padded.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

