### PR TITLE
Integrate qkv_proj_with_rope

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -662,7 +662,12 @@ class DeepseekV2AttentionMLA(nn.Module):
                 else:
                     return self.forward_absorb(positions, hidden_states, forward_batch)
             else:
-                return self.forward_absorb(positions, hidden_states, forward_batch)
+                if self.q_lora_rank is not None and self.use_intel_amx_backend:
+                    return self.forward_absorb_fused_mla_rope_cpu(
+                        positions, hidden_states, forward_batch
+                    )
+                else:
+                    return self.forward_absorb(positions, hidden_states, forward_batch)
 
     def forward_normal(
         self,
@@ -712,99 +717,65 @@ class DeepseekV2AttentionMLA(nn.Module):
         hidden_states: torch.Tensor,
         forward_batch: ForwardBatch,
     ) -> torch.Tensor:
-        # TODO: add sth like forward_absorb_fused_mla_rope
-        if self.q_lora_rank is not None and self.use_intel_amx_backend:
-            q_input, k_input, v_input = sgl_kernel.cpu.qkv_proj_with_rope(
-                hidden_states,
-                self.q_a_proj.weight,
-                self.q_b_proj.weight,
-                self.kv_a_proj_with_mqa.weight,
-                self.w_kc,
-                self.q_a_layernorm.weight,
-                self.kv_a_layernorm.weight,
-                positions,
-                self.rotary_emb.cos_sin_cache,
-                self.kv_a_layernorm.variance_epsilon,
-                use_int8_w8a8=self.qkv_proj_with_rope_is_int8,
-                q_a_proj_scale=(
-                    self.q_a_proj.weight_scale
-                    if self.qkv_proj_with_rope_is_int8
-                    else None
-                ),
-                q_b_proj_scale=(
-                    self.q_b_proj.weight_scale
-                    if self.qkv_proj_with_rope_is_int8
-                    else None
-                ),
-                kv_a_proj_scale=(
-                    self.kv_a_proj_with_mqa.weight_scale
-                    if self.qkv_proj_with_rope_is_int8
-                    else None
-                ),
+        q_len = hidden_states.shape[0]
+        q_input = hidden_states.new_empty(
+            q_len, self.num_local_heads, self.kv_lora_rank + self.qk_rope_head_dim
+        )
+        if self.q_lora_rank is not None:
+            q = self.q_a_proj(hidden_states)[0]
+            q = self.q_a_layernorm(q)
+            q = self.q_b_proj(q)[0].view(-1, self.num_local_heads, self.qk_head_dim)
+        else:
+            q = self.q_proj(hidden_states)[0].view(
+                -1, self.num_local_heads, self.qk_head_dim
+            )
+        q_nope, q_pe = q.split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
+
+        if self.w_kc.dtype == torch.float8_e4m3fnuz:
+            # TODO(kernel): add bmm_fp8 for torch.float8_e4m3fnuz
+            q_nope_out = torch.bmm(
+                q_nope.to(torch.bfloat16).transpose(0, 1),
+                self.w_kc.to(torch.bfloat16) * self.w_scale,
+            )
+        elif self.w_kc.dtype == torch.float8_e4m3fn:
+            q_nope_val, q_nope_scale = input_to_float8(
+                q_nope.transpose(0, 1), torch.float8_e4m3fn
+            )
+            q_nope_out = bmm_fp8(
+                q_nope_val, self.w_kc, q_nope_scale, self.w_scale, torch.bfloat16
             )
         else:
-            q_len = hidden_states.shape[0]
-            q_input = hidden_states.new_empty(
-                q_len, self.num_local_heads, self.kv_lora_rank + self.qk_rope_head_dim
-            )
+            if self.use_intel_amx_backend:
+                # [Note] Align shapes of bmm inputs.
+                # Shapes of inputs:
+                #   q_nope: [M, B, K]
+                #   original self.w_kc: [B, K, N]
+                #   current self.w_kc (which has been converted in PackWeightMethod): [B, N, K]
 
-            if self.q_lora_rank is not None:
-                q = self.q_a_proj(hidden_states)[0]
-                q = self.q_a_layernorm(q)
-                q = self.q_b_proj(q)[0].view(-1, self.num_local_heads, self.qk_head_dim)
+                # Shapes of inputs to sgl_kernel.cpu.bmm:
+                #   out: [B, M, N]
+                #   mat1: [B, M, K]
+                #   mat2: [B, N, K]
+                B = self.w_kc.size(0)
+                N = self.w_kc.size(1)
+                M = q_nope.size(0)
+
+                q_nope_out = q_input[..., : self.kv_lora_rank].transpose_(0, 1)
+                sgl_kernel.cpu.bmm(q_nope_out, q_nope.transpose(0, 1), self.w_kc)
             else:
-                q = self.q_proj(hidden_states)[0].view(
-                    -1, self.num_local_heads, self.qk_head_dim
-                )
-            q_nope, q_pe = q.split(
-                [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1
-            )
+                q_nope_out = torch.bmm(q_nope.transpose(0, 1), self.w_kc)
+                q_input[..., : self.kv_lora_rank] = q_nope_out.transpose(0, 1)
 
-            if self.w_kc.dtype == torch.float8_e4m3fnuz:
-                # TODO(kernel): add bmm_fp8 for torch.float8_e4m3fnuz
-                q_nope_out = torch.bmm(
-                    q_nope.to(torch.bfloat16).transpose(0, 1),
-                    self.w_kc.to(torch.bfloat16) * self.w_scale,
-                )
-            elif self.w_kc.dtype == torch.float8_e4m3fn:
-                q_nope_val, q_nope_scale = input_to_float8(
-                    q_nope.transpose(0, 1), torch.float8_e4m3fn
-                )
-                q_nope_out = bmm_fp8(
-                    q_nope_val, self.w_kc, q_nope_scale, self.w_scale, torch.bfloat16
-                )
-            else:
-                if self.use_intel_amx_backend:
-                    # [Note] Align shapes of bmm inputs.
-                    # Shapes of inputs:
-                    #   q_nope: [M, B, K]
-                    #   original self.w_kc: [B, K, N]
-                    #   current self.w_kc (which has been converted in PackWeightMethod): [B, N, K]
+        latent_cache = self.kv_a_proj_with_mqa(hidden_states)[0]
+        v_input = latent_cache[..., : self.kv_lora_rank]
+        v_input = self.kv_a_layernorm(v_input.contiguous()).unsqueeze(1)
+        k_input = latent_cache.unsqueeze(1)
+        k_input[..., : self.kv_lora_rank] = v_input
+        k_pe = k_input[..., self.kv_lora_rank :]
 
-                    # Shapes of inputs to sgl_kernel.cpu.bmm:
-                    #   out: [B, M, N]
-                    #   mat1: [B, M, K]
-                    #   mat2: [B, N, K]
-                    B = self.w_kc.size(0)
-                    N = self.w_kc.size(1)
-                    M = q_nope.size(0)
-
-                    q_nope_out = q_input[..., : self.kv_lora_rank].transpose_(0, 1)
-                    sgl_kernel.cpu.bmm(q_nope_out, q_nope.transpose(0, 1), self.w_kc)
-                else:
-                    q_nope_out = torch.bmm(q_nope.transpose(0, 1), self.w_kc)
-                    q_input[..., : self.kv_lora_rank] = q_nope_out.transpose(0, 1)
-
-            latent_cache = self.kv_a_proj_with_mqa(hidden_states)[0]
-            v_input = latent_cache[..., : self.kv_lora_rank]
-            v_input = self.kv_a_layernorm(v_input.contiguous()).unsqueeze(1)
-            k_input = latent_cache.unsqueeze(1)
-            k_input[..., : self.kv_lora_rank] = v_input
-            k_pe = k_input[..., self.kv_lora_rank :]
-
-            q_pe, k_pe = self.rotary_emb(positions, q_pe, k_pe)
-            q_input[..., self.kv_lora_rank :] = q_pe
-            k_input[..., self.kv_lora_rank :] = k_pe
+        q_pe, k_pe = self.rotary_emb(positions, q_pe, k_pe)
+        q_input[..., self.kv_lora_rank :] = q_pe
+        k_input[..., self.kv_lora_rank :] = k_pe
 
         attn_output = self.attn_mqa(q_input, k_input, v_input, forward_batch)
         attn_output = attn_output.view(-1, self.num_local_heads, self.kv_lora_rank)
@@ -984,6 +955,72 @@ class DeepseekV2AttentionMLA(nn.Module):
         else:
             attn_bmm_output = torch.bmm(attn_output.transpose(0, 1), self.w_vc)
         attn_output = attn_bmm_output.transpose(0, 1).flatten(1, 2)
+        output, _ = self.o_proj(attn_output)
+
+        return output
+
+    def forward_absorb_fused_mla_rope_cpu(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+        assert (
+            self.q_lora_rank is not None and self.use_intel_amx_backend
+        ), "forward_absorb_fused_mla_rope_cpu requires q_lora_rank is not None and use_intel_amx_backend"
+        q_input, k_input, v_input = sgl_kernel.cpu.qkv_proj_with_rope(
+            hidden_states,
+            self.q_a_proj.weight,
+            self.q_b_proj.weight,
+            self.kv_a_proj_with_mqa.weight,
+            self.w_kc,
+            self.q_a_layernorm.weight,
+            self.kv_a_layernorm.weight,
+            positions,
+            self.rotary_emb.cos_sin_cache,
+            self.kv_a_layernorm.variance_epsilon,
+            use_int8_w8a8=self.qkv_proj_with_rope_is_int8,
+            q_a_proj_scale=(
+                self.q_a_proj.weight_scale if self.qkv_proj_with_rope_is_int8 else None
+            ),
+            q_b_proj_scale=(
+                self.q_b_proj.weight_scale if self.qkv_proj_with_rope_is_int8 else None
+            ),
+            kv_a_proj_scale=(
+                self.kv_a_proj_with_mqa.weight_scale
+                if self.qkv_proj_with_rope_is_int8
+                else None
+            ),
+        )
+        attn_output = self.attn_mqa(q_input, k_input, v_input, forward_batch)
+        attn_output = attn_output.view(-1, self.num_local_heads, self.kv_lora_rank)
+
+        if self.w_vc.dtype == torch.float8_e4m3fnuz:
+            # TODO(kernel): add bmm_fp8 for torch.float8_e4m3fnuz
+            attn_bmm_output = torch.bmm(
+                attn_output.to(torch.bfloat16).transpose(0, 1),
+                self.w_vc.to(torch.bfloat16) * self.w_scale,
+            )
+        elif self.w_vc.dtype == torch.float8_e4m3fn:
+            attn_output_val, attn_output_scale = input_to_float8(
+                attn_output.transpose(0, 1), torch.float8_e4m3fn
+            )
+            attn_bmm_output = bmm_fp8(
+                attn_output_val,
+                self.w_vc,
+                attn_output_scale,
+                self.w_scale,
+                torch.bfloat16,
+            )
+        else:
+            # See [Note] Align shapes of bmm inputs.
+            B = self.w_vc.size(0)
+            N = self.w_vc.size(1)
+            M = attn_output.size(0)
+            output = torch.empty([M, int(B * N)], dtype=attn_output.dtype)
+            attn_bmm_output = output.view([M, B, N]).transpose_(0, 1)
+            sgl_kernel.cpu.bmm(attn_bmm_output, attn_output.transpose(0, 1), self.w_vc)
+            attn_output = output
         output, _ = self.o_proj(attn_output)
 
         return output

--- a/sgl-kernel/python/sgl_kernel/cpu.py
+++ b/sgl-kernel/python/sgl_kernel/cpu.py
@@ -66,6 +66,42 @@ def convert_weight_packed(weight):
     return sgl_kernel.common_ops.convert_weight_packed(weight)
 
 
+def qkv_proj_with_rope(
+    hidden_states,
+    q_a_proj_weight,
+    q_b_proj_weight,
+    kv_a_proj_weight,
+    w_kc,
+    q_a_layernorm_weight,
+    kv_a_layernorm_weight,
+    positions,
+    cos_sin_cache,
+    eps,
+    use_int8_w8a8=False,
+    q_a_proj_scale=None,
+    q_b_proj_scale=None,
+    kv_a_proj_scale=None,
+    is_vnni=True,
+):
+    return sgl_kernel.common_ops.qkv_proj_with_rope(
+        hidden_states,
+        q_a_proj_weight,
+        q_b_proj_weight,
+        kv_a_proj_weight,
+        w_kc,
+        q_a_layernorm_weight,
+        kv_a_layernorm_weight,
+        positions,
+        cos_sin_cache,
+        eps,
+        use_int8_w8a8,
+        q_a_proj_scale,
+        q_b_proj_scale,
+        kv_a_proj_scale,
+        is_vnni,
+    )
+
+
 def decode_attention(
     q,
     k_buffer,


### PR DESCRIPTION
## Modifications

<!-- Describe the changes made in this PR. -->

If `q_lora_rank is not None` and `use_intel_amx_backend`, add a `forward_absorb_fused_mla_rope_cpu` call which directly invokes the `sgl_kernel.cpu.qkv_proj_with_rope` kernel.

## Test
For INT8, verified on `meituan/DeepSeek-R1-Channel-INT8` (`q_lora_rank is not None` for this model) that the generated sentence is good:
input: `'The capital city of France is'`
output: `' Paris. Paris is located in the northern'`

For BF16, verified on `deepseek-ai/DeepSeek-Coder-V2-Instruct` (`q_lora_rank is not None` for this model) that the generated sentence is good:
input: `'The capital city of France is'`
output: `' Paris.\n\nThe capital city of'`