### PR TITLE
CPU CI enabling: enabling CPU CI workflows 

### DIFF
--- a/.github/workflows/pr-test-cpu.yml
+++ b/.github/workflows/pr-test-cpu.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Run standard tests
         timeout-minutes: 20
         run: |
-          docker exec -w /root/sglang ci_sglang_cpu python -m sglang.bench_one_batch --batch-size 1 --input 32 --output 32 --model deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B --trust-remote-code --device cpu
+          echo "[placeholder] for upcoming testcases...."
       - name: Cleanup container
         if: always() 
         run: |

--- a/.github/workflows/pr-test-cpu.yml
+++ b/.github/workflows/pr-test-cpu.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Run standard tests
         timeout-minutes: 20
         run: |
-          docker exec -w /sglang-checkout ci_sglang_cpu python -m sglang.bench_one_batch --batch-size 1 --input 32 --output 32 --model meta-llama/Meta-Llama-3.1-8B-Instruct --trust-remote-code --device cpu
+          docker exec -w /sglang-checkout ci_sglang_cpu python -m sglang.bench_one_batch --batch-size 1 --input 32 --output 32 --model deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B --trust-remote-code --device cpu
       - name: Cleanup container
         if: always() 
         run: |

--- a/.github/workflows/pr-test-cpu.yml
+++ b/.github/workflows/pr-test-cpu.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Run standard tests
         timeout-minutes: 20
         run: |
-          docker exec -w /sglang-checkout ci_sglang_cpu pytest -v sglang/test/srt/test_custom_allreduce.py
+          docker exec -w /sglang-checkout ci_sglang_cpu pytest -v test/srt/test_custom_allreduce.py
           
       - name: Run standard tests
         timeout-minutes: 20

--- a/.github/workflows/pr-test-cpu.yml
+++ b/.github/workflows/pr-test-cpu.yml
@@ -44,18 +44,13 @@ jobs:
       - name: Run standard tests
         timeout-minutes: 20
         run: |
-          docker exec -w /sglang-checkout ci_sglang_cpu pytest -n auto sglang/test/
-
-      - name: Run benchmark tests
-        timeout-minutes: 15
+          docker exec -w /sglang-checkout ci_sglang_cpu pytest -v sglang/test/srt/test_custom_allreduce.py
+          
+      - name: Run standard tests
+        timeout-minutes: 20
         run: |
-          docker exec -w /sglang-checkout ci_sglang_cpu python3 sglang/test/benchmark/test_benchmark.py
+          docker exec -w /sglang-checkout ci_sglang_cpu python -m sglang.bench_one_batch --batch-size 1 --input 32 --output 32 --model meta-llama/Meta-Llama-3.1-8B-Instruct --trust-remote-code --device cpu 
 
-      - name: Run accuracy tests
-        timeout-minutes: 15
-        run: |
-          docker exec -w /sglang-checkout ci_sglang_cpu python3 sglang/test/accuracy/test_accuracy.py
-          docker exec -w /sglang-checkout ci_sglang_cpu python3 sglang/test/accuracy/test_fp8_accuracy.py
 
   finish:
     if: always()

--- a/.github/workflows/pr-test-cpu.yml
+++ b/.github/workflows/pr-test-cpu.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Dependency
         timeout-minutes: 20
         run: |
-          docker exec -w /sglang-checkout ci_sglang_cpu pip install pytest expecttest
+          docker exec -w /sglang-checkout ci_sglang_cpu pip install pytest expecttest ray
           
       - name: Run standard tests
         timeout-minutes: 20

--- a/.github/workflows/pr-test-cpu.yml
+++ b/.github/workflows/pr-test-cpu.yml
@@ -44,11 +44,6 @@ jobs:
       - name: Run standard tests
         timeout-minutes: 20
         run: |
-          docker exec -w /sglang-checkout ci_sglang_cpu pytest -v test/srt/test_custom_allreduce.py
-          
-      - name: Run standard tests
-        timeout-minutes: 20
-        run: |
           docker exec -w /sglang-checkout ci_sglang_cpu python -m sglang.bench_one_batch --batch-size 1 --input 32 --output 32 --model meta-llama/Meta-Llama-3.1-8B-Instruct --trust-remote-code --device cpu
       - name: Cleanup container
         if: always() 

--- a/.github/workflows/pr-test-cpu.yml
+++ b/.github/workflows/pr-test-cpu.yml
@@ -28,23 +28,27 @@ jobs:
       - name: Run container
         run: |
           docker run -dt \
-            -v ${{ github.workspace }}:/sglang-checkout \
             -e https_proxy="http://proxy-dmz.intel.com:912/" \
             -e http_proxy="http://proxy-dmz.intel.com:912/" \
             -e no_proxy=".intel.com" \
-            -w /sglang-checkout \
+            -w /root/sglang \
             --name ci_sglang_cpu \
             sglang-cpu-test
 
       - name: Install Dependency
         timeout-minutes: 20
         run: |
-          docker exec -w /sglang-checkout ci_sglang_cpu pip install pytest expecttest ray
+          docker exec -w /root/sglang ci_sglang_cpu pip install pytest expecttest ray
           
+      - name: Run UT Cases
+        timeout-minutes: 20
+        run: |
+          docker exec -w /root/sglang ci_sglang_cpu pytest -v test/srt/test_custom_allreduce.py
+     
       - name: Run standard tests
         timeout-minutes: 20
         run: |
-          docker exec -w /sglang-checkout ci_sglang_cpu python -m sglang.bench_one_batch --batch-size 1 --input 32 --output 32 --model deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B --trust-remote-code --device cpu
+          docker exec -w /root/sglang ci_sglang_cpu python -m sglang.bench_one_batch --batch-size 1 --input 32 --output 32 --model deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B --trust-remote-code --device cpu
       - name: Cleanup container
         if: always() 
         run: |

--- a/.github/workflows/pr-test-cpu.yml
+++ b/.github/workflows/pr-test-cpu.yml
@@ -49,7 +49,11 @@ jobs:
       - name: Run standard tests
         timeout-minutes: 20
         run: |
-          docker exec -w /sglang-checkout ci_sglang_cpu python -m sglang.bench_one_batch --batch-size 1 --input 32 --output 32 --model meta-llama/Meta-Llama-3.1-8B-Instruct --trust-remote-code --device cpu 
+          docker exec -w /sglang-checkout ci_sglang_cpu python -m sglang.bench_one_batch --batch-size 1 --input 32 --output 32 --model meta-llama/Meta-Llama-3.1-8B-Instruct --trust-remote-code --device cpu
+      - name: Cleanup container
+        if: always() 
+        run: |
+          docker rm -f ci_sglang_cpu || true
 
 
   finish:

--- a/.github/workflows/pr-test-cpu.yml
+++ b/.github/workflows/pr-test-cpu.yml
@@ -1,0 +1,80 @@
+name: PR Test (CPU)
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - "python/sglang/**"
+      - "test/**"
+      - "sgl-kernel/**"
+  pull_request:
+    branches: [ main ]
+    paths:
+      - "python/sglang/**"
+      - "test/**"
+      - "sgl-kernel/**"
+  workflow_dispatch:
+
+concurrency:
+  group: pr-test-cpu-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') &&
+      github.event.pull_request.draft == false
+    runs-on: emr-7470
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: |
+          docker build --build-arg no_proxy=.intel.com --build-arg http_proxy=http://proxy-dmz.intel.com:912 --build-arg https_proxy=http://proxy-dmz.intel.com:912 \
+          -t sglang-cpu-test  -f Dockerfile .
+
+      - name: Run container
+        run: |
+          docker run -dt \
+            -v ${{ github.workspace }}:/sglang-checkout \
+            -e https_proxy="http://proxy-dmz.intel.com:912/" \
+            -e http_proxy="http://proxy-dmz.intel.com:912/" \
+            -e no_proxy=".intel.com" 
+            -w /sglang-checkout \
+            --name ci_sglang_cpu \
+            sglang-cpu-test
+
+      - name: Install Dependency
+        timeout-minutes: 20
+        run: |
+          docker exec -w /sglang-checkout ci_sglang_cpu pip install pytest expecttest
+          
+      - name: Run standard tests
+        timeout-minutes: 20
+        run: |
+          docker exec -w /sglang-checkout ci_sglang_cpu pytest -n auto sglang/test/
+
+      - name: Run benchmark tests
+        timeout-minutes: 15
+        run: |
+          docker exec -w /sglang-checkout ci_sglang_cpu python3 sglang/test/benchmark/test_benchmark.py
+
+      - name: Run accuracy tests
+        timeout-minutes: 15
+        run: |
+          docker exec -w /sglang-checkout ci_sglang_cpu python3 sglang/test/accuracy/test_accuracy.py
+          docker exec -w /sglang-checkout ci_sglang_cpu python3 sglang/test/accuracy/test_fp8_accuracy.py
+
+  finish:
+    if: always()
+    needs: [build-and-test]
+    runs-on: emr-7470
+    steps:
+      - name: Check job status
+        run: |
+          if [ "${{ needs.build-and-test.result }}" != "success" ]; then
+            echo "Job failed with result: ${{ needs.build-and-test.result }}"
+            exit 1
+          fi
+          echo "All jobs completed successfully"
+          exit 0

--- a/.github/workflows/pr-test-cpu.yml
+++ b/.github/workflows/pr-test-cpu.yml
@@ -31,7 +31,7 @@ jobs:
             -v ${{ github.workspace }}:/sglang-checkout \
             -e https_proxy="http://proxy-dmz.intel.com:912/" \
             -e http_proxy="http://proxy-dmz.intel.com:912/" \
-            -e no_proxy=".intel.com" 
+            -e no_proxy=".intel.com" \
             -w /sglang-checkout \
             --name ci_sglang_cpu \
             sglang-cpu-test

--- a/.github/workflows/pr-test-cpu.yml
+++ b/.github/workflows/pr-test-cpu.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Build Docker image
         run: |
           docker build --build-arg no_proxy=.intel.com --build-arg http_proxy=http://proxy-dmz.intel.com:912 --build-arg https_proxy=http://proxy-dmz.intel.com:912 \
-          -t sglang-cpu-test  -f Dockerfile .
+          -t sglang-cpu-test  -f ${{ github.workspace }}/docker/Dockerfile.xeon .
 
       - name: Run container
         run: |

--- a/.github/workflows/pr-test-cpu.yml
+++ b/.github/workflows/pr-test-cpu.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Build Docker image
         run: |
           docker build --build-arg no_proxy=.intel.com --build-arg http_proxy=http://proxy-dmz.intel.com:912 --build-arg https_proxy=http://proxy-dmz.intel.com:912 \
-          -t sglang-cpu-test  -f ${{ github.workspace }}/docker/Dockerfile.xeon .
+          -t sglang-cpu-test  -f docker/Dockerfile.xeon .
 
       - name: Run container
         run: |

--- a/.github/workflows/pr-test-cpu.yml
+++ b/.github/workflows/pr-test-cpu.yml
@@ -3,16 +3,8 @@ name: PR Test (CPU)
 on:
   push:
     branches: [ main ]
-    paths:
-      - "python/sglang/**"
-      - "test/**"
-      - "sgl-kernel/**"
   pull_request:
     branches: [ main ]
-    paths:
-      - "python/sglang/**"
-      - "test/**"
-      - "sgl-kernel/**"
   workflow_dispatch:
 
 concurrency:

--- a/docker/Dockerfile.xeon
+++ b/docker/Dockerfile.xeon
@@ -1,0 +1,50 @@
+FROM ubuntu:24.04
+SHELL ["/bin/bash", "-c"]
+
+RUN if [ -f /etc/apt/apt.conf.d/proxy.conf ]; then rm /etc/apt/apt.conf.d/proxy.conf; fi && \
+    if [ ! -z ${HTTPS_PROXY} ]; then echo "Acquire::https::Proxy \"${HTTPS_PROXY}\";" >> /etc/apt/apt.conf.d/proxy.conf; fi
+RUN apt-get update && \
+    apt-get full-upgrade -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    ca-certificates \
+    git \
+    curl \
+    wget \
+    vim \
+    libnuma-dev \
+    gcc \
+    g++ \
+    make
+
+WORKDIR /root
+
+RUN curl -fsSL -v -o miniforge.sh -O https://github.com/conda-forge/miniforge/releases/download/24.11.3-2/Miniforge3-24.11.3-2-Linux-x86_64.sh && \
+    bash miniforge.sh -b -p ./miniforge3 && \
+    rm -f miniforge.sh && \
+    . miniforge3/bin/activate && \
+    conda install -y libsqlite=3.48.0 gperftools tbb
+
+ENV PATH=/root/miniforge3/bin:/root/miniforge3/condabin:${PATH}
+ENV PIP_ROOT_USER_ACTION=ignore
+
+RUN pip install cmake==3.31.2 \
+    "setuptools-scm>=8" \
+    intel-openmp \
+    triton==3.1
+RUN git clone https://github.com/vllm-project/vllm.git && \
+    cd vllm && \
+    git checkout v0.6.4.post1 && \
+    pip install -v -r requirements-cpu.txt --extra-index-url https://download.pytorch.org/whl/cpu && \
+    VLLM_TARGET_DEVICE=cpu python setup.py develop && \
+    cd ..
+RUN git clone https://github.com/mingfeima/sglang.git && \
+    cd sglang && \
+    git checkout cpu_opt_ww11 && \
+    pip install torch==2.6.0 torchvision==0.21.0 --index-url https://download.pytorch.org/whl/cpu --force-reinstall && \
+    pip install -e "python[all_cpu]" && \
+    cd sgl-kernel && \
+    python setup.py install
+
+ENV LD_PRELOAD=/root/miniforge3/lib/libiomp5.so:/root/miniforge3/lib/libtcmalloc.so:/root/miniforge3/lib/libtbbmalloc.so.2
+
+WORKDIR /root/sglang


### PR DESCRIPTION
enabling Upstream sglang CPU CI

1. Most cases in tests/ failed since device are hardcode as cuda
2. Currently, dockerfile.xeon has a strict dependency on the internal proxy, which means the temporary CI environment also relies on it.
 