### PR TITLE
fix moe fp8 avx512-bf16

### DIFF
--- a/sgl-kernel/csrc/cpu/gemm_fp8.cpp
+++ b/sgl-kernel/csrc/cpu/gemm_fp8.cpp
@@ -420,7 +420,7 @@ void tinygemm_kernel(
     int64_t ldc,
     bool brg,
     int64_t block_size_K) {
-  tinygemm_kernel<scalar_t, false>(A, B, C, Btmp, Ctmp, scale, nullptr, M, N, K, lda, ldb, ldc, brg, K);
+  tinygemm_kernel<scalar_t, false>(A, B, C, Btmp, Ctmp, scale, nullptr, M, N, K, lda, ldb, ldc, brg, block_size_K);
 }
 
 #define INSTANTIATE_TINYGEMM_TEMPLATE(TYPE)    \

--- a/sgl-kernel/csrc/cpu/moe_fp8.cpp
+++ b/sgl-kernel/csrc/cpu/moe_fp8.cpp
@@ -94,9 +94,7 @@ void shared_expert_fp8_kernel_impl(
   int64_t scale_size_K = div_up(K, block_size_K);
   int64_t blocks_n_per_group = block_size_N / BLOCK_N;
 
-  // TODO: enable avx512-bf16 impl
-  // const bool use_brgemm = can_use_brgemm<at::Float8_e4m3fn>(M);
-  bool use_brgemm = true;
+  const bool use_brgemm = can_use_brgemm<at::Float8_e4m3fn>(M);
 
   at::parallel_for(0, MB * NB, 0, [&](int64_t begin, int64_t end) {
     alignas(64) scalar_t Btmp[BLOCK_N * BLOCK_K];


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

Fixes the correctness issue of moe fp8.
Enable the avx512-bf16 for moe fp8.

python -u [test_moe_fp8.py](https://github.com/mingfeima/sgl-cpu-tests/blob/fd3b4f586ef5cb09764445afa5ec43d365f83041/test_moe_fp8.py) can pass now after the fix:
```
torch.bfloat16 torch.bfloat16 torch.bfloat16
tensor([[-0.4277,  0.1279, -0.2314,  ...,  0.0801, -0.5430,  0.3750],
        [ 0.2324,  0.2500, -0.1396,  ...,  0.3496,  0.0339, -0.3965]],
       dtype=torch.bfloat16)
tensor([[-0.4277,  0.1279, -0.2324,  ...,  0.0796, -0.5391,  0.3770],
        [ 0.2354,  0.2520, -0.1426,  ...,  0.3477,  0.0339, -0.3965]],
       dtype=torch.bfloat16)
428 tensor(-0.5234, dtype=torch.bfloat16) tensor(-0.5156, dtype=torch.bfloat16)
Comparing:  True  max_diff = 0.00781, asum = 6.875, bsum = 6.781
torch.bfloat16 torch.bfloat16 torch.bfloat16
tensor([[-0.4277,  0.3047, -0.2334,  ...,  0.0260,  0.6680, -0.9219],
        [ 0.9648, -0.3262,  0.6641,  ..., -0.5703,  0.9531, -0.0535],
        [-0.0530,  0.1572, -0.0913,  ...,  0.8281, -0.0791,  0.0251],
        ...,
        [ 0.4062,  0.5586, -0.0175,  ...,  0.5703,  0.7617,  0.0903],
        [-0.8594,  0.4648, -0.1118,  ...,  0.8359,  0.3047, -0.7227],
        [ 0.3145,  0.8438, -0.4316,  ..., -0.5625, -0.7305,  0.8516]],
       dtype=torch.bfloat16)
tensor([[-0.4277,  0.3047, -0.2344,  ...,  0.0271,  0.6680, -0.9219],
        [ 0.9648, -0.3262,  0.6641,  ..., -0.5703,  0.9492, -0.0530],
        [-0.0540,  0.1543, -0.0923,  ...,  0.8281, -0.0781,  0.0264],
        ...,
        [ 0.4062,  0.5547, -0.0172,  ...,  0.5703,  0.7617,  0.0903],
        [-0.8594,  0.4688, -0.1089,  ...,  0.8359,  0.3047, -0.7188],
        [ 0.3145,  0.8438, -0.4336,  ..., -0.5625, -0.7305,  0.8516]],
       dtype=torch.bfloat16)
4558 tensor(-1.3125, dtype=torch.bfloat16) tensor(-1.3281, dtype=torch.bfloat16)
Comparing:  True  max_diff = 0.01562, asum = 142.000, bsum = 142.000
```

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

