### PR TITLE
Molly/ut enabling

### DIFF
--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -267,7 +267,7 @@ def auto_detect_device() -> str:
         return "cuda"
     elif hasattr(torch.version, "hip") and torch.version.hip:
         return "rocm"
-    elif hasattr(torch, 'xpu') and torch.xpu.is_available():  # Check for Intel XPU
+    elif hasattr(torch, "xpu") and torch.xpu.is_available():  # Check for Intel XPU
         return "xpu"
     else:
         return "cpu"

--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -1,8 +1,8 @@
 """Common utilities for testing and benchmarking"""
 
 import argparse
-import copy
 import asyncio
+import copy
 import os
 import random
 import subprocess
@@ -258,6 +258,7 @@ def add_common_other_args_and_parse(parser: argparse.ArgumentParser):
         args.port = default_port.get(args.backend, None)
     return args
 
+
 def auto_detect_device() -> str:
     """Auto-detect available device platform"""
     import torch
@@ -269,6 +270,7 @@ def auto_detect_device() -> str:
     else:
         return "cpu"
 
+
 def add_common_sglang_args_and_parse(parser: argparse.ArgumentParser):
     parser.add_argument("--parallel", type=int, default=64)
     parser.add_argument("--host", type=str, default="http://127.0.0.1")
@@ -279,7 +281,7 @@ def add_common_sglang_args_and_parse(parser: argparse.ArgumentParser):
         type=str,
         default="auto",
         choices=["auto", "cuda", "rocm", "cpu"],
-        help="Device type (auto/cuda/rocm/cpu). Auto will detect available platforms"
+        help="Device type (auto/cuda/rocm/cpu). Auto will detect available platforms",
     )
     parser.add_argument("--result-file", type=str, default="result.jsonl")
     args = parser.parse_args()
@@ -373,7 +375,7 @@ def popen_launch_server(
     env: Optional[dict] = None,
     return_stdout_stderr: Optional[tuple] = None,
     pd_seperated: bool = False,
-    device: str = "auto"
+    device: str = "auto",
 ):
     """Launch a server process with automatic device detection.
 
@@ -599,7 +601,7 @@ def get_benchmark_args(
         lora_name=None,
         prompt_suffix="",
         pd_seperated=pd_seperated,
-        device=device
+        device=device,
     )
 
 
@@ -645,7 +647,7 @@ def run_bench_serving(
         disable_stream=disable_stream,
         disable_ignore_eos=disable_ignore_eos,
         seed=seed,
-        device=device
+        device=device,
     )
 
     try:
@@ -696,7 +698,6 @@ def run_bench_serving_multi(
 
 
 def run_bench_one_batch(model, other_args):
-
     """Launch a offline process with automatic device detection.
 
     Args:

--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -267,6 +267,8 @@ def auto_detect_device() -> str:
         return "cuda"
     elif hasattr(torch.version, "hip") and torch.version.hip:
         return "rocm"
+    elif hasattr(torch, 'xpu') and torch.xpu.is_available():  # Check for Intel XPU
+        return "xpu"
     else:
         return "cpu"
 

--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -261,7 +261,7 @@ def add_common_other_args_and_parse(parser: argparse.ArgumentParser):
 def auto_detect_device() -> str:
     """Auto-detect available device platform"""
     import torch
-    
+
     if torch.cuda.is_available():
         return "cuda"
     elif hasattr(torch.version, "hip") and torch.version.hip:
@@ -275,15 +275,15 @@ def add_common_sglang_args_and_parse(parser: argparse.ArgumentParser):
     parser.add_argument("--port", type=int, default=30000)
     parser.add_argument("--backend", type=str, default="srt")
     parser.add_argument(
-        "--device", 
-        type=str, 
-        default="auto",  
-        choices=["auto", "cuda", "rocm", "cpu"],  
+        "--device",
+        type=str,
+        default="auto",
+        choices=["auto", "cuda", "rocm", "cpu"],
         help="Device type (auto/cuda/rocm/cpu). Auto will detect available platforms"
     )
     parser.add_argument("--result-file", type=str, default="result.jsonl")
     args = parser.parse_args()
-    
+
     return args
 
 
@@ -373,12 +373,12 @@ def popen_launch_server(
     env: Optional[dict] = None,
     return_stdout_stderr: Optional[tuple] = None,
     pd_seperated: bool = False,
-    device: str = "auto"  
+    device: str = "auto"
 ):
     """Launch a server process with automatic device detection.
-    
+
     Args:
-        device: Device type ("auto", "cuda", "rocm" or "cpu"). 
+        device: Device type ("auto", "cuda", "rocm" or "cpu").
                 If "auto", will detect available platforms automatically.
     """
     # Auto-detect device if needed
@@ -694,9 +694,9 @@ def run_bench_serving_multi(
 def run_bench_one_batch(model, other_args):
 
     """Launch a offline process with automatic device detection.
-    
+
     Args:
-        device: Device type ("auto", "cuda", "rocm" or "cpu"). 
+        device: Device type ("auto", "cuda", "rocm" or "cpu").
                 If "auto", will detect available platforms automatically.
     """
     # Auto-detect device if needed

--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -458,11 +458,6 @@ def popen_launch_server(
                     return process
             except requests.RequestException:
                 pass
-
-            return_code = process.poll()
-            if return_code is not None:
-                raise Exception(f"Server unexpectedly exits ({return_code=}).")
-
             time.sleep(10)
 
     kill_process_tree(process.pid)
@@ -493,7 +488,7 @@ def run_with_timeout(
     return ret_value[0]
 
 
-def run_unittest_files(files: List[TestFile], timeout_per_file: float):
+def run_unittest_files(files: List, timeout_per_file: float):
     tic = time.time()
     success = True
 
@@ -811,7 +806,6 @@ def run_and_check_memory_leak(
     if disable_overlap:
         other_args += ["--disable-overlap-schedule"]
 
-
     model = DEFAULT_MODEL_NAME_FOR_TEST
     port = random.randint(4000, 5000)
     base_url = f"http://127.0.0.1:{port}"
@@ -929,6 +923,7 @@ def run_mulit_request_test(
     enable_overlap=False,
     chunked_prefill_size=32,
 ):
+
     def workload_func(base_url, model):
         def run_one(_):
             prompt = """
@@ -1040,4 +1035,3 @@ def run_logprob_check(self: unittest.TestCase, arg: Tuple):
                                 rank += 1
                             else:
                                 raise
-

--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -369,7 +369,7 @@ def popen_launch_server(
     base_url: str,
     timeout: float,
     api_key: Optional[str] = None,
-    other_args: list[str] = (),
+    other_args: list[str] = [],
     env: Optional[dict] = None,
     return_stdout_stderr: Optional[tuple] = None,
     pd_seperated: bool = False,
@@ -385,6 +385,7 @@ def popen_launch_server(
     if device == "auto":
         device = auto_detect_device()
         print(f"Auto-detected device: {device}", flush=True)
+        other_args = list(other_args)
         other_args += ["--device", str(device)]
 
     _, host, port = base_url.split(":")
@@ -567,7 +568,7 @@ def get_benchmark_args(
     disable_ignore_eos=False,
     seed: int = 0,
     pd_seperated: bool = False,
-    device=None,
+    device="auto",
 ):
     return SimpleNamespace(
         backend="sglang",
@@ -617,7 +618,10 @@ def run_bench_serving(
     disable_ignore_eos=False,
     need_warmup=False,
     seed: int = 0,
+    device="auto",
 ):
+    if device == "auto":
+        device = auto_detect_device()
     # Launch the server
     base_url = DEFAULT_URL_FOR_TEST
     process = popen_launch_server(

--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -10,6 +10,7 @@ import threading
 import time
 import unittest
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
 from functools import partial
 from types import SimpleNamespace
 from typing import Callable, List, Optional, Tuple
@@ -616,7 +617,6 @@ def run_bench_serving(
     disable_ignore_eos=False,
     need_warmup=False,
     seed: int = 0,
-    device=None
 ):
     # Launch the server
     base_url = DEFAULT_URL_FOR_TEST
@@ -692,6 +692,19 @@ def run_bench_serving_multi(
 
 
 def run_bench_one_batch(model, other_args):
+
+    """Launch a offline process with automatic device detection.
+    
+    Args:
+        device: Device type ("auto", "cuda", "rocm" or "cpu"). 
+                If "auto", will detect available platforms automatically.
+    """
+    # Auto-detect device if needed
+
+    device = auto_detect_device()
+    print(f"Auto-detected device: {device}", flush=True)
+    other_args += ["--device", str(device)]
+
     command = [
         "python3",
         "-m",


### PR DESCRIPTION
## Motivation
 Propose adding an auto-detection mechanism for hardware platforms (e.g., CUDA, ROCm, CPU) in SGLang UT Test. This will simplify deployment and improve compatibility across different environments. 

Current Limitation: Users must manually specify --device (e.g., cuda, rocm, cpu), which is error-prone.

vLLM Inspiration: vLLM’s auto_detect_device() automatically selects the optimal backend.

Goal: Reduce configuration overhead and ensure SGLang runs on the best available hardware.


## Modifications

Add auto_detect_device() in python/sglang/test/test_utils.py

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
