### PR TITLE
add runtime check for server setup in UT cases

### DIFF
--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -447,16 +447,16 @@ def popen_launch_server(
     start_time = time.time()
     with requests.Session() as session:
         while time.time() - start_time < timeout:
-            
+
             # check if server process has crashe/exited
-            return_code = process.poll() 
+            return_code = process.poll()
             if return_code is not None:
                 # Server failed to start (non-zero exit code) or crashed
                 raise Exception(
                     f"Server process exited with code {return_code}. "
                     "Check server logs for errors."
                 )
-                
+
             try:
                 headers = {
                     "Content-Type": "application/json; charset=utf-8",


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Currently, if the server fails to start (e.g., due to configuration errors or missing dependencies), the script continues retrying health checks until timeout. This:

- Wastes time in CI/CD pipelines
- Delays feedback during development
- Masks root causes by showing timeout errors instead of actual startup failures


## Modifications

Modify the server health check script to fail immediately if the server process crashes during startup, rather than waiting for the full timeout period.


## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
