### PR TITLE
De-couple vLLM CPU and remove dependency of `sudo apt-get install libnuma-dev`

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -63,10 +63,8 @@ srt_xpu = ["sglang[runtime_common]", "outlines>=0.0.44,<=0.1.11"]
 # https://docs.vllm.ai/en/latest/getting_started/gaudi-installation.html
 srt_hpu = ["sglang[runtime_common]", "outlines>=0.0.44,<=0.1.11"]
 
-# CPU: currently, there are no pre-built vllm wheels for CPU.
-# To install vllm for CPU, please follow the instruction here:
-# https://docs.vllm.ai/en/latest/getting_started/installation/cpu/index.html
-srt_cpu = ["sglang[runtime_common]", "outlines>=0.0.44,<=0.1.11", "torch"]
+# CPU: torch wheel for CPU needs to be installed from https://download.pytorch.org/whl/cpu
+srt_cpu = ["sglang[runtime_common]", "outlines>=0.0.44,<=0.1.11", "vllm>=0.6.4.post1,<=0.7.2"]
 
 openai = ["openai>=1.0", "tiktoken"]
 anthropic = ["anthropic>=0.20.0"]

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -307,12 +307,12 @@ class ModelRunner:
 
         if not self.is_draft_worker:
             if self.device == "cpu":
-                # Bind OpenMP threads to CPU cores
-                if self.local_omp_cpuid != "all":
-                    torch.ops._C_utils.init_cpu_threads_env(self.local_omp_cpuid)
-
                 # Initialization of shm all_reduce
                 import sgl_kernel.common_ops
+
+                # Bind OpenMP threads to CPU cores
+                if self.local_omp_cpuid != "all":
+                    sgl_kernel.common_ops.init_cpu_threads_env(self.local_omp_cpuid)
 
                 shm_comm_op = sgl_kernel.common_ops
                 # Set local size to hint SGLang to use shared memory based AllReduce

--- a/sgl-kernel/csrc/cpu/numa_utils.cpp
+++ b/sgl-kernel/csrc/cpu/numa_utils.cpp
@@ -4,7 +4,6 @@
 #include <sched.h>
 
 #include "common.h"
-// #include "cpu_types.hpp"
 
 std::string init_cpu_threads_env(const std::string& cpu_ids) {
   bitmask* omp_cpu_mask = numa_parse_cpustring(cpu_ids.c_str());
@@ -49,8 +48,8 @@ std::string init_cpu_threads_env(const std::string& cpu_ids) {
 
   // OMP threads binding
   omp_set_num_threads((int)omp_cpu_ids.size());
-  torch::set_num_threads((int)omp_cpu_ids.size());
-  TORCH_CHECK_EQ(omp_cpu_ids.size(), torch::get_num_threads());
+  at::set_num_threads((int)omp_cpu_ids.size());
+  TORCH_CHECK_EQ(omp_cpu_ids.size(), at::get_num_threads());
   TORCH_CHECK_EQ(omp_cpu_ids.size(), omp_get_max_threads());
 
   std::vector<std::pair<int, int>> thread_core_mapping;

--- a/sgl-kernel/csrc/cpu/numa_utils.cpp
+++ b/sgl-kernel/csrc/cpu/numa_utils.cpp
@@ -1,0 +1,91 @@
+#include <numa.h>
+#include <unistd.h>
+#include <string>
+#include <sched.h>
+
+#include "common.h"
+// #include "cpu_types.hpp"
+
+std::string init_cpu_threads_env(const std::string& cpu_ids) {
+  bitmask* omp_cpu_mask = numa_parse_cpustring(cpu_ids.c_str());
+  TORCH_CHECK(omp_cpu_mask->size > 0);
+  std::vector<int> omp_cpu_ids;
+  omp_cpu_ids.reserve(omp_cpu_mask->size);
+
+  constexpr int group_size = 8 * sizeof(*omp_cpu_mask->maskp);
+
+  for (int offset = 0; offset < omp_cpu_mask->size; offset += group_size) {
+    unsigned long group_mask = omp_cpu_mask->maskp[offset / group_size];
+    int i = 0;
+    while (group_mask) {
+      if (group_mask & 1) {
+        omp_cpu_ids.emplace_back(offset + i);
+      }
+      ++i;
+      group_mask >>= 1;
+    }
+  }
+
+  // Memory node binding
+  if (numa_available() != -1) {
+    int mem_node_id = numa_node_of_cpu(omp_cpu_ids.front());
+    bitmask* mask = numa_parse_nodestring(std::to_string(mem_node_id).c_str());
+    bitmask* src_mask = numa_get_membind();
+
+    int pid = getpid();
+
+    // move all existing pages to the specified numa node.
+    *(src_mask->maskp) = *(src_mask->maskp) ^ *(mask->maskp);
+    int page_num = numa_migrate_pages(pid, src_mask, mask);
+    if (page_num == -1) {
+      TORCH_CHECK(false,
+                  "numa_migrate_pages failed. errno: " + std::to_string(errno));
+    }
+
+    // restrict memory allocation node.
+    numa_set_membind(mask);
+    numa_set_strict(1);
+  }
+
+  // OMP threads binding
+  omp_set_num_threads((int)omp_cpu_ids.size());
+  torch::set_num_threads((int)omp_cpu_ids.size());
+  TORCH_CHECK_EQ(omp_cpu_ids.size(), torch::get_num_threads());
+  TORCH_CHECK_EQ(omp_cpu_ids.size(), omp_get_max_threads());
+
+  std::vector<std::pair<int, int>> thread_core_mapping;
+  thread_core_mapping.reserve(omp_cpu_ids.size());
+  omp_lock_t writelock;
+  omp_init_lock(&writelock);
+
+#pragma omp parallel for schedule(static, 1)
+  for (size_t i = 0; i < omp_cpu_ids.size(); ++i) {
+    cpu_set_t mask;
+    CPU_ZERO(&mask);
+    CPU_SET(omp_cpu_ids[i], &mask);
+    int ret = sched_setaffinity(0, sizeof(cpu_set_t), &mask);
+    if (ret == -1) {
+      TORCH_CHECK(false,
+                  "sched_setaffinity failed. errno: " + std::to_string(errno));
+    }
+
+    omp_set_lock(&writelock);
+    thread_core_mapping.emplace_back(gettid(), omp_cpu_ids[i]);
+    omp_unset_lock(&writelock);
+  }
+
+  omp_destroy_lock(&writelock);
+
+  numa_free_nodemask(omp_cpu_mask);
+
+  std::stringstream ss;
+  ss << "OMP threads binding of Process " << getpid() << ":\n";
+  std::sort(thread_core_mapping.begin(), thread_core_mapping.end(),
+            [](auto&& a, auto&& b) { return a.second < b.second; });
+  for (auto&& item : thread_core_mapping) {
+    ss << "\t"
+       << "OMP tid: " << item.first << ", core " << item.second << "\n";
+  }
+
+  return ss.str();
+}

--- a/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
+++ b/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
@@ -282,7 +282,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
 
   // rope
   m.def("rotary_position_embedding_cpu", &rotary_position_embedding_cpu, "rotary position embedding for CPU");
-  
+
   // CPU and memory binding
   m.def("init_cpu_threads_env", &init_cpu_threads_env, "CPU and memory binding");
 }

--- a/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
+++ b/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
@@ -216,6 +216,9 @@ at::Tensor shm_allgather(at::Tensor& data, c10::intrusive_ptr<c10d::ProcessGroup
 std::tuple<at::Tensor, at::Tensor> rotary_position_embedding_cpu(at::Tensor& t_pos, at::Tensor& q_pe,
     at::Tensor& k_pe, at::Tensor& t_emb_pos);
 
+// CPU and memory binding
+std::string init_cpu_threads_env(const std::string& cpu_ids);
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   // activation
   m.def("silu_and_mul_cpu", &silu_and_mul_cpu, "SiLU and mul for CPU");
@@ -279,4 +282,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
 
   // rope
   m.def("rotary_position_embedding_cpu", &rotary_position_embedding_cpu, "rotary position embedding for CPU");
+  
+  // CPU and memory binding
+  m.def("init_cpu_threads_env", &init_cpu_threads_env, "CPU and memory binding");
 }

--- a/sgl-kernel/setup.py
+++ b/sgl-kernel/setup.py
@@ -249,7 +249,7 @@ if cpu_fp8_ftz:
 if cpu_amx_int8:
     extra_compile_args["cxx"].append("-DSGLANG_CPU_AMX_INT8")
 
-libraries = ["c10", "torch", "torch_python"]
+libraries = ["c10", "torch", "torch_python", "numa"]
 cuda_libraries = ["cuda", "cublas"]
 cmdclass = {
     "build_ext": BuildExtension.with_options(use_ninja=True),
@@ -272,7 +272,7 @@ extra_link_args = ["-Wl,-rpath,$ORIGIN/../../torch/lib", "-L/usr/lib/x86_64-linu
 
 # https://github.com/pytorch/pytorch/issues/152243
 py_limited_api = version.parse(torch.__version__) < version.parse("2.7")
-
+conda_prefix = os.getenv("CONDA_PREFIX", "")
 ext_modules = [
     Extension(
         name="sgl_kernel.common_ops",
@@ -280,6 +280,7 @@ ext_modules = [
         include_dirs=include_dirs,
         extra_compile_args=extra_compile_args,
         libraries=libraries,
+        library_dirs=[os.path.join(conda_prefix, "lib")] if conda_prefix else [],
         extra_link_args=extra_link_args,
         py_limited_api=py_limited_api,
     ),

--- a/sgl-kernel/setup.py
+++ b/sgl-kernel/setup.py
@@ -158,6 +158,7 @@ sources = [
     "csrc/cpu/moe_fp8.cpp",
     "csrc/cpu/moe_int8.cpp",
     "csrc/cpu/norm.cpp",
+    "csrc/cpu/numa_utils.cpp",
     "csrc/cpu/qkv_proj.cpp",
     "csrc/cpu/rope.cpp",
     "csrc/cpu/topk.cpp",


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This PR de-couples vLLM CPU and remove dependency of `sudo apt-get install libnuma-dev`.

**Before this PR,** users need to build CPU vllm wheel themselves because we need to call the below function in vllm:
```
torch.ops._C_utils.init_cpu_threads_env(self.local_omp_cpuid)
```
In addition, `sudo apt-get install libnuma-dev` is needed since the above function needs `#include <numa.h>`.

In this PR, we port this function into `sgl-kernel`, users need to install libnuma via conda and `numa.h` in the conda env will be used.

**After is PR**, users could directly install vllm wheel from pip and there's no need to do `sudo apt-get install libnuma-dev`.

The BKC after this PR will be like:
```
# Create conda ENV
conda create -n sglang python=3.10
conda activate sglang

# Install SGLang
# Change to git clone https://github.com/mingfeima/sglang.git once the PR lands
git clone https://github.com/chunyuan-w/sglang.git

cd sglang

# Change to git checkout cpu_opt_ww11 once the PR lands
git checkout chunyuan/pr_ww11_numa_bind 

pip install -e "python[all_cpu]"

conda install -y libsqlite=3.48.0

# When installing vllm, torch 2.5.1 is installed. To build sgl-kernel, we need to use torch cpu 2.6. Thus the below 2 steps are needed.
pip uninstall torch torchvision
pip3 install torch==2.6.0 torchvision==0.21.0 --index-url https://download.pytorch.org/whl/cpu

# Build sgl-kernel
conda install -y libnuma numactl

cd sgl-kernel
python setup.py install

cd ..

conda install -y gperftools -c conda-forge
pip install intel-openmp==2024.2.0
```


## Modifications

- We ported the [init_cpu_threads_env](https://github.com/vllm-project/vllm/blob/v0.7.2/csrc/cpu/utils.cpp#L11) from vLLM into `sgl-kernel`.
- We add `numa` as a library into setup.py and we will use the libnuma in conda ENV.


## TODO

- [ ] fix vLLM related warning when running the workload in SGLang
- [ ] how to ensure libnuma is installed in the conda ENV
- [ ] test on more machines
- [ ] update the BKC when this PR lands
