### PR TITLE
Automatically bind threads if `SGLANG_CPU_OMP_THREADS_BIND` is not set

### DIFF
--- a/python/sglang/srt/cpu_utils.py
+++ b/python/sglang/srt/cpu_utils.py
@@ -238,8 +238,13 @@ def torch_w8a8_per_column_moe(a, w1, w2, w1_s, w2_s, topk_weight, topk_ids, topk
 
 
 def parse_lscpu_topology():
-    # Get CPU topology: CPU,Core,Socket,Node
-    output = subprocess.check_output(["lscpu", "-p=CPU,Core,Socket,Node"], text=True)
+    try:
+        # Get CPU topology: CPU,Core,Socket,Node
+        output = subprocess.check_output(
+            ["lscpu", "-p=CPU,Core,Socket,Node"], text=True
+        )
+    except Exception as e:
+        raise RuntimeError(f"Unexpected error running 'lscpu': {e}")
 
     # Parse only data lines (skip comments)
     cpu_info = []

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -166,9 +166,11 @@ class ModelRunner:
             cpu_ids_by_node = get_cpu_ids_by_node()
             n_numa_node = len(cpu_ids_by_node)
 
-            assert (
-                self.tp_size <= n_numa_node
-            ), f"tp_size {self.tp_size} should be smaller than number of numa node on the machine {n_numa_node}"
+            assert self.tp_size <= n_numa_node, (
+                f"SGLANG_CPU_OMP_THREADS_BIND is not set, in this case, "
+                f"tp_size {self.tp_size} should be smaller than number of numa node on the machine {n_numa_node}. "
+                f"If you need tp_size to be larger than number of numa node, please set the CPU cores for each tp rank via SGLANG_CPU_OMP_THREADS_BIND explicitly."
+            )
             self.local_omp_cpuid = cpu_ids_by_node[self.tp_rank]
         else:
             self.local_omp_cpuid = omp_cpuids.split("|")[tp_rank]

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -169,8 +169,17 @@ class ModelRunner:
             assert self.tp_size <= n_numa_node, (
                 f"SGLANG_CPU_OMP_THREADS_BIND is not set, in this case, "
                 f"tp_size {self.tp_size} should be smaller than number of numa node on the machine {n_numa_node}. "
-                f"If you need tp_size to be larger than number of numa node, please set the CPU cores for each tp rank via SGLANG_CPU_OMP_THREADS_BIND explicitly."
+                f"If you need tp_size to be larger than number of numa node, please set the CPU cores for each tp rank via SGLANG_CPU_OMP_THREADS_BIND explicitly. "
+                f"For example, on a machine with 2 numa nodes, where core 0-31 are on numa node 0 and core 32-63 are on numa node 1, "
+                f"it is suggested to use -tp 2 and bind tp rank 0 to core 0-31 and tp rank 1 to core 32-63. "
+                f"This is the default behavior if SGLANG_CPU_OMP_THREADS_BIND is not set and it is the same as setting SGLANG_CPU_OMP_THREADS_BIND=0-31|32-63. "
+                f"If you do need tp_size to be large than the number of numa nodes, you could set SGLANG_CPU_OMP_THREADS_BIND explicitly for example SGLANG_CPU_OMP_THREADS_BIND=0-15|16-31|32-47|48-63 and run with -tp 4. "
+                f"If you don't want each tp rank to use all the cores on one numa node, you could set for example SGLANG_CPU_OMP_THREADS_BIND=0-15|32-47 and run with -tp 2."
             )
+            if self.tp_size < n_numa_node:
+                logger.warning(
+                    f"Detected the current machine has {n_numa_node} numa nodes available, but tp_size is set to {self.tp_size}, so use only {self.tp_size} numa nodes are used."
+                )
             self.local_omp_cpuid = cpu_ids_by_node[self.tp_rank]
         else:
             self.local_omp_cpuid = omp_cpuids.split("|")[tp_rank]


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Previously, users were required to manually set the `SGLANG_CPU_OMP_THREADS_BIND` environment variable to ensure proper thread binding across NUMA nodes.
This PR improves the user experience by automatically setting `SGLANG_CPU_OMP_THREADS_BIND` when it is not explicitly set by the user. The code determines the binding based on the NUMA topology.

For example, to run tp_size = 6 on a machine with 6 sub-numa nodes, the command line before this PR:
```
SGLANG_CPU_OMP_THREADS_BIND="0-42|43-85|86-127|128-170|171-213|214-255" python3 -m sglang.bench_one_batch --batch-size 1 --input 1024 --output 8 --model  deepseek-ai/DeepSeek-R1  --trust-remote-code --device cpu --tp 6
```

The command line after this PR (only -`-tp` is needed, `SGLANG_CPU_OMP_THREADS_BIND` no longer needs to be set):
```
python3 -m sglang.bench_one_batch --batch-size 1 --input 1024 --output 8 --model  deepseek-ai/DeepSeek-R1  --trust-remote-code --device cpu --tp 6
```

## Modifications
When `SGLANG_CPU_OMP_THREADS_BIND` is not set, we only support tp_size to be smaller than the number of sub-numa nodes on the current machine and we will bind each tp rank to one sub-numa node. We only bind to physical cores. Logical cores are excluded.
If this is not satisfied, an error message is thrown:
```
AssertionError: SGLANG_CPU_OMP_THREADS_BIND is not set, in this case, tp_size 8 should be smaller than number of numa node on the machine 6. If you need tp_size to be larger than number of numa node, please set the CPU cores for each tp rank via SGLANG_CPU_OMP_THREADS_BIND explicitly.
```

If users do need the tp_size to be larger than the number of sub-numa nodes or they don't want to use the whole sub-numa node for one tp rank, they can still set the binding via `SGLANG_CPU_OMP_THREADS_BIND` as before.

If `-tp` is not parsed, it means tp_size = 1, in this case, if `SGLANG_CPU_OMP_THREADS_BIND` is not set, we will bind to sub-numa node 0.

## Benchmark
Verified DeepSeek R1 INT8 bench_one_batch performance (BS=1, TP=6), with this PR, by removing `SGLANG_CPU_OMP_THREADS_BIND` in the command line, the performance won't be impacted. 

## TODO

- [ ] update BKC when this PR lands (cc @ZailiWang)

