### PR TITLE
fix head_dim in qwen2 when num_attention_heads is padded

### DIFF
--- a/python/sglang/srt/cpu_utils.py
+++ b/python/sglang/srt/cpu_utils.py
@@ -72,6 +72,11 @@ def update_config(
     weight_block_size = may_get_weight_block_size(model_config, load_config)
 
     if model_config.num_attention_heads % tp_size != 0:
+        # Compute the head_dim using the model_config.num_attention_heads before padding
+        model_config.hf_config.original_head_dim = (
+            model_config.hidden_size // model_config.num_attention_heads
+        )
+
         query_heads_per_kv = (
             model_config.num_attention_heads // model_config.get_total_num_kv_heads()
         )

--- a/python/sglang/srt/models/qwen2.py
+++ b/python/sglang/srt/models/qwen2.py
@@ -94,6 +94,7 @@ class Qwen2Attention(nn.Module):
         hidden_size: int,
         num_heads: int,
         num_kv_heads: int,
+        head_dim: Optional[int] = None,
         layer_id: int = 0,
         rope_theta: float = 1000000,
         rope_scaling: Optional[Dict[str, Any]] = None,
@@ -117,7 +118,10 @@ class Qwen2Attention(nn.Module):
             # the KV heads across multiple tensor parallel GPUs.
             assert tp_size % self.total_num_kv_heads == 0
         self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
-        self.head_dim = hidden_size // self.total_num_heads
+        if head_dim is not None:
+            self.head_dim = head_dim
+        else:
+            self.head_dim = hidden_size // self.total_num_heads
         self.q_size = self.num_heads * self.head_dim
         self.kv_size = self.num_kv_heads * self.head_dim
         self.scaling = self.head_dim**-0.5
@@ -184,10 +188,12 @@ class Qwen2DecoderLayer(nn.Module):
         rope_theta = getattr(config, "rope_theta", 1000000)
         rope_scaling = getattr(config, "rope_scaling", None)
         max_position_embeddings = getattr(config, "max_position_embeddings", 32768)
+        head_dim = getattr(config, "original_head_dim", None)
         self.self_attn = Qwen2Attention(
             hidden_size=self.hidden_size,
             num_heads=config.num_attention_heads,
             num_kv_heads=config.num_key_value_heads,
+            head_dim=head_dim,
             layer_id=layer_id,
             rope_theta=rope_theta,
             rope_scaling=rope_scaling,


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Fixes the failure of `Qwen/Qwen2-7B-Instruct` when running TP = 6.
In qwen2, `head_dim` is computed using `self.head_dim = hidden_size // self.total_num_heads`. But here the `self.total_num_heads` has already been padded if `num_attention_heads % tp_size != 0`. Thus the computed `head_dim` is wrong.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications
If `num_attention_heads` is padded, we compute the `head_dim` using the num heads before the padding and save it in the config of the model.

TODO:
1. Several other models also compute `head_dim` this way. We need to make frontend changes in other models as well.
2. cpu_opt_ww11 branch can't run qwen2 yet. Need to fix the TP padding for `QKVParallelLinear`, etc.


<!-- Describe the changes made in this PR. -->

