### PR TITLE
Draft: K-blocking heuristics for weight_packed_linear CPU GEMM

### DIFF
--- a/sgl-kernel/csrc/cpu/gemm.cpp
+++ b/sgl-kernel/csrc/cpu/gemm.cpp
@@ -300,6 +300,39 @@ struct tinygemm_kernel_nn<at::BFloat16, has_bias, BLOCK_M, BLOCK_N> {
 
 template <typename scalar_t, bool has_bias>
 struct brgemm {
+  // Single K-panel matmul into FP32 Ctmp.  Set add_C=true to accumulate along K.
+  static inline void compute(
+      const scalar_t* __restrict__ A,
+      const scalar_t* __restrict__ B,
+      float* __restrict__ Ctmp,
+      int64_t M,
+      int64_t N,
+      int64_t K,
+      int64_t lda,
+      int64_t ldb,
+      bool add_C) {
+    constexpr int BLOCK_N = block_size_n();
+    at::native::cpublas::brgemm(M, N, K, lda, ldb, BLOCK_N, add_C, A, B, Ctmp);
+  }
+
+  static inline void store(
+      scalar_t* __restrict__ C,
+      const float* __restrict__ Ctmp,
+      const float* __restrict__ bias,
+      int64_t M,
+      int64_t N,
+      int64_t ldc) {
+    constexpr int BLOCK_N = block_size_n();
+    for (int64_t m = 0; m < M; ++m) {
+      if constexpr (has_bias) {
+        copy_add_stub(C + m * ldc, Ctmp + m * BLOCK_N, bias, N);
+      } else {
+        copy_stub(C + m * ldc, Ctmp + m * BLOCK_N, N);
+      }
+    }
+  }
+
+  // Legacy full-K helper (still used by tinygemm fallback).
   static inline void apply(
       const scalar_t* __restrict__ A,
       const scalar_t* __restrict__ B,
@@ -312,18 +345,24 @@ struct brgemm {
       int64_t lda,
       int64_t ldb,
       int64_t ldc) {
-    constexpr int BLOCK_N = block_size_n();
-    at::native::cpublas::brgemm(M, N, K, lda, ldb, BLOCK_N, /* add_C */ false, A, B, Ctmp);
-
-    // copy from Ctmp to C
-    for (int64_t m = 0; m < M; ++m) {
-      if constexpr (has_bias) {
-        copy_add_stub(C + m * ldc, Ctmp + m * BLOCK_N, bias, N);
-      } else {
-        copy_stub(C + m * ldc, Ctmp + m * BLOCK_N, N);
-      }
-    }
+    compute(A, B, Ctmp, M, N, K, lda, ldb, /* add_C */ false);
+    store(C, Ctmp, bias, M, N, ldc);
   }
+
+  static inline void compute(
+      const float* __restrict__ A,
+      const float* __restrict__ B,
+      float* __restrict__ Ctmp,
+      int64_t M,
+      int64_t N,
+      int64_t K,
+      int64_t lda,
+      int64_t ldb,
+      bool add_C) {
+    constexpr int BLOCK_N = block_size_n();
+    at::native::cpublas::brgemm(M, N, K, lda, ldb, BLOCK_N, add_C, A, B, Ctmp);
+  }
+
   static inline void apply(
       const float* __restrict__ A,
       const float* __restrict__ B,
@@ -336,8 +375,7 @@ struct brgemm {
       int64_t lda,
       int64_t ldb,
       int64_t ldc) {
-    constexpr int BLOCK_N = block_size_n();
-    at::native::cpublas::brgemm(M, N, K, lda, ldb, BLOCK_N, /* add_C */ false, A, B, Ctmp);
+    compute(A, B, Ctmp, M, N, K, lda, ldb, /* add_C */ false);
   }
 };
 
@@ -454,6 +492,107 @@ void tinygemm_kernel(
   // TODO : add intrinsic path
 }
 
+// Shared blocked GEMM driver for VNNI weight_packed_linear.
+//
+// Loop nest (mirrors oneDNN horizontal matmul):
+//   parallel_2d(M_chunk, N_chunk)
+//     for k0 in K step k_blk          // K-chunk, accumulate with add_C
+//       for n in [n0, n1) step TILE_N // N micro tile
+//         for m in [m0, m1) step TILE_M
+//           brgemm / tinygemm
+//           store on last K-chunk
+template <typename scalar_t, bool has_bias>
+void weight_packed_linear_blocked(
+    scalar_t* __restrict__ out,
+    const scalar_t* __restrict__ mat1,
+    const scalar_t* __restrict__ mat2,
+    const float* __restrict__ bias,
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    int64_t mat1_strideM,
+    int64_t out_strideM) {
+  constexpr int64_t TILE_M = block_size_m();
+  constexpr int64_t TILE_N = block_size_n();
+
+  const gemm_blocking_params params = compute_gemm_blocking(M, N, K, sizeof(scalar_t));
+  const int64_t MC = div_up(M, params.m_par);
+  const int64_t NC = div_up(N, params.n_par);
+  const bool use_brgemm = can_use_brgemm<scalar_t>(M);
+
+  parallel_2d(MC, NC, [&](int64_t mc0, int64_t mc1, int64_t nc0, int64_t nc1) {
+    alignas(64) float Ctmp[TILE_M * TILE_N];
+
+    for (int64_t mc = mc0; mc < mc1; ++mc) {
+      const int64_t m_par_start = mc * params.m_par;
+      const int64_t m_par_end = std::min(M, m_par_start + params.m_par);
+
+      for (int64_t nc = nc0; nc < nc1; ++nc) {
+        const int64_t n_par_start = nc * params.n_par;
+        const int64_t n_par_end = std::min(N, n_par_start + params.n_par);
+
+        if (use_brgemm) {
+          // K-chunk outermost: reuse each B[:, k0:k0+k_blk) panel across all M.
+          for (int64_t k0 = 0; k0 < K; k0 += params.k_blk) {
+            const int64_t k_size = std::min(params.k_blk, K - k0);
+            const bool first_k = (k0 == 0);
+            const bool last_k = (k0 + k_size >= K);
+
+            for (int64_t n = n_par_start; n < n_par_end; n += TILE_N) {
+              const int64_t n_size = std::min(TILE_N, n_par_end - n);
+
+              for (int64_t m = m_par_start; m < m_par_end; m += TILE_M) {
+                const int64_t m_size = std::min(TILE_M, m_par_end - m);
+
+                brgemm<scalar_t, has_bias>::compute(
+                    mat1 + m * mat1_strideM + k0,
+                    mat2 + n * K + k0,
+                    Ctmp,
+                    m_size,
+                    n_size,
+                    k_size,
+                    mat1_strideM,
+                    n_size,
+                    !first_k);
+
+                if (last_k) {
+                  brgemm<scalar_t, has_bias>::store(
+                      out + m * out_strideM + n, Ctmp, bias + n, m_size, n_size, out_strideM);
+                }
+              }
+            }
+          }
+        } else {
+          // Small-M AVX512 path: keep full-K tinygemm (M <= 4 for bf16).
+          for (int64_t n = n_par_start; n < n_par_end; n += TILE_N) {
+            const int64_t n_size = std::min(TILE_N, n_par_end - n);
+            for (int64_t m = m_par_start; m < m_par_end; m += TILE_M) {
+              const int64_t m_size = std::min(TILE_M, m_par_end - m);
+              tinygemm_kernel<scalar_t, has_bias>(
+                  mat1 + m * mat1_strideM,
+                  mat2 + n * K,
+                  out + m * out_strideM + n,
+                  Ctmp,
+                  bias + n,
+                  m_size,
+                  n_size,
+                  K,
+                  mat1_strideM,
+                  n_size,
+                  out_strideM,
+                  /* brg */ false);
+            }
+          }
+        }
+      }
+    }
+
+    if (use_brgemm) {
+      at::native::cpublas::brgemm_release();
+    }
+  });
+}
+
 template <typename scalar_t>
 void weight_packed_linear_kernel_impl(
     scalar_t* __restrict__ out,
@@ -465,44 +604,9 @@ void weight_packed_linear_kernel_impl(
     int64_t K,
     int64_t mat1_strideM,
     int64_t out_strideM) {
-  constexpr int64_t BLOCK_M = block_size_m();
-  constexpr int64_t BLOCK_N = block_size_n();
-  const int64_t MB = div_up(M, BLOCK_M);
-  const int64_t NB = div_up(N, BLOCK_N);
-
-  const bool use_brgemm = can_use_brgemm<scalar_t>(M);
-
-  // parallel on [MB, NB]
   AT_DISPATCH_BOOL(bias != nullptr, has_bias, [&] {
-    parallel_2d(MB, NB, [&](int64_t mb0, int64_t mb1, int64_t nb0, int64_t nb1) {
-      // for brgemm, use float32 for accumulate
-      alignas(64) float Ctmp[BLOCK_M * BLOCK_N];
-
-      loop_2d<scalar_t>(mb0, mb1, nb0, nb1, BLOCK_N * K, [&](int64_t mb, int64_t nb, int64_t nb_offset) {
-        int64_t mb_start = mb * BLOCK_M;
-        int64_t mb_size = std::min(M - mb_start, BLOCK_M);
-        int64_t nb_start = nb * BLOCK_N;
-        int64_t nb_size = std::min(N - nb_start, BLOCK_N);
-
-        tinygemm_kernel<scalar_t, has_bias>(
-            /*   A */ mat1 + mb_start * mat1_strideM,
-            /*   B */ mat2 + nb_start * K /* nb * BLOCK_N * K */,
-            /*   C */ out + mb_start * out_strideM + nb_start,
-            /* Ctmp*/ Ctmp,
-            /* bias*/ bias + nb_start,
-            /*   M */ mb_size,
-            /*   N */ nb_size,
-            /*   K */ K,
-            /* lda */ mat1_strideM,
-            /* ldb */ nb_size,
-            /* ldc */ out_strideM,
-            /* brg */ use_brgemm);
-      });
-
-      if (use_brgemm) {
-        at::native::cpublas::brgemm_release();
-      }
-    });
+    weight_packed_linear_blocked<scalar_t, has_bias>(
+        out, mat1, mat2, bias, M, N, K, mat1_strideM, out_strideM);
   });
 }
 
@@ -518,65 +622,67 @@ void weight_packed_linear_kernel_impl(
     int64_t K,
     int64_t mat1_strideM,
     int64_t out_strideM) {
-  constexpr int64_t BLOCK_M = block_size_m();
-  constexpr int64_t BLOCK_N = block_size_n();
-  const int64_t MB = div_up(M, BLOCK_M);
-  const int64_t NB = div_up(N, BLOCK_N);
+  constexpr int64_t TILE_M = block_size_m();
+  constexpr int64_t TILE_N = block_size_n();
 
-  const bool use_brgemm = true;  // TODO: add intrinsic path
-  // parallel on [MB, NB]
+  const gemm_blocking_params params = compute_gemm_blocking(M, N, K, sizeof(scalar_t));
+  const int64_t MC = div_up(M, params.m_par);
+  const int64_t NC = div_up(N, params.n_par);
+
+  alignas(64) float Atmp[TILE_M * gemm_max_k_blk()];
+
   AT_DISPATCH_BOOL(bias != nullptr, has_bias, [&] {
-    parallel_2d(MB, NB, [&](int64_t mb0, int64_t mb1, int64_t nb0, int64_t nb1) {
-      // for brgemm, use float32 for accumulate
-      alignas(64) float Atmp[BLOCK_M * K];
-      alignas(64) float Ctmp[BLOCK_M * BLOCK_N];
+    parallel_2d(MC, NC, [&](int64_t mc0, int64_t mc1, int64_t nc0, int64_t nc1) {
+      alignas(64) float Ctmp[TILE_M * TILE_N];
 
-      loop_2d<float>(mb0, mb1, nb0, nb1, BLOCK_N * K, [&](int64_t mb, int64_t nb, int64_t nb_offset) {
-        int64_t mb_start = mb * BLOCK_M;
-        int64_t mb_size = std::min(M - mb_start, BLOCK_M);
-        int64_t nb_start = nb * BLOCK_N;
-        int64_t nb_size = std::min(N - nb_start, BLOCK_N);
-        for (int64_t m = 0; m < mb_size; ++m) {
-          copy_stub<scalar_t>(Atmp + m * K, mat1 + mb_start * mat1_strideM + m * K, K);
-        }
-        tinygemm_kernel<scalar_t, has_bias>(
-            /*   A */ Atmp,
-            /*   B */ mat2 + nb_start * K /* nb * BLOCK_N * K */,
-            /*   C */ out + mb_start * out_strideM + nb_start,
-            /* Ctmp*/ Ctmp,
-            /* bias*/ bias + nb_start,
-            /*   M */ mb_size,
-            /*   N */ nb_size,
-            /*   K */ K,
-            /* lda */ mat1_strideM,
-            /* ldb */ nb_size,
-            /* ldc */ out_strideM,
-            /* brg */ use_brgemm);
+      for (int64_t mc = mc0; mc < mc1; ++mc) {
+        const int64_t m_par_start = mc * params.m_par;
+        const int64_t m_par_end = std::min(M, m_par_start + params.m_par);
 
-        if (post_mul_mat != nullptr) {
-          for (int64_t m = 0; m < mb_size; ++m) {
-            scalar_sigmoid_and_mul<scalar_t, has_bias>(
-                out + mb_start * out_strideM + nb_start + m * out_strideM,
-                Ctmp + m * BLOCK_N,
-                bias + nb_start,
-                post_mul_mat + mb_start * out_strideM + m * out_strideM,
-                out_strideM);
-          }
-        } else {
-          for (int64_t m = 0; m < mb_size; ++m) {
-            if constexpr (has_bias) {
-              copy_add_stub(
-                  out + mb_start * out_strideM + nb_start + m * out_strideM, Ctmp + m * BLOCK_N, bias + nb_start, N);
-            } else {
-              copy_stub(out + mb_start * out_strideM + nb_start + m * out_strideM, Ctmp + m * BLOCK_N, N);
+        for (int64_t nc = nc0; nc < nc1; ++nc) {
+          const int64_t n_par_start = nc * params.n_par;
+          const int64_t n_par_end = std::min(N, n_par_start + params.n_par);
+
+          for (int64_t k0 = 0; k0 < K; k0 += params.k_blk) {
+            const int64_t k_size = std::min(params.k_blk, K - k0);
+            const bool first_k = (k0 == 0);
+            const bool last_k = (k0 + k_size >= K);
+
+            for (int64_t n = n_par_start; n < n_par_end; n += TILE_N) {
+              const int64_t n_size = std::min(TILE_N, n_par_end - n);
+
+              for (int64_t m = m_par_start; m < m_par_end; m += TILE_M) {
+                const int64_t m_size = std::min(TILE_M, m_par_end - m);
+
+                for (int64_t mm = 0; mm < m_size; ++mm) {
+                  copy_stub<scalar_t>(Atmp + mm * k_size, mat1 + (m + mm) * mat1_strideM + k0, k_size);
+                }
+
+                brgemm<scalar_t, has_bias>::compute(
+                    Atmp, mat2 + n * K + k0, Ctmp, m_size, n_size, k_size, k_size, n_size, !first_k);
+
+                if (last_k) {
+                  if (post_mul_mat != nullptr) {
+                    for (int64_t mm = 0; mm < m_size; ++mm) {
+                      scalar_sigmoid_and_mul<scalar_t, has_bias>(
+                          out + (m + mm) * out_strideM + n,
+                          Ctmp + mm * TILE_N,
+                          bias + n,
+                          post_mul_mat + (m + mm) * out_strideM + n,
+                          n_size);
+                    }
+                  } else {
+                    brgemm<scalar_t, has_bias>::store(
+                        out + m * out_strideM + n, Ctmp, bias + n, m_size, n_size, out_strideM);
+                  }
+                }
+              }
             }
           }
         }
-      });
-
-      if (use_brgemm) {
-        at::native::cpublas::brgemm_release();
       }
+
+      at::native::cpublas::brgemm_release();
     });
   });
 }

--- a/sgl-kernel/csrc/cpu/gemm.h
+++ b/sgl-kernel/csrc/cpu/gemm.h
@@ -16,6 +16,68 @@ constexpr int block_size_n() {
   return 2 * TILE_N;
 }
 
+// ---------------------------------------------------------------------------
+// Simplified GEMM blocking heuristics (inspired by oneDNN matmul AMX path)
+//
+// oneDNN splits the problem into:
+//   * micro tiles  (M_blk / N_blk / K_blk)  -> single brgemm call
+//   * parallel chunks (M_chunk / N_chunk)   -> thread assignment unit
+//   * K-chunk loop with add_C accumulation  -> keep A/B panels in L2
+//
+// We mirror that layout with a small, fixed heuristic instead of the full
+// bandwidth-model search in amx_blocking_heuristics.cpp.
+// ---------------------------------------------------------------------------
+struct gemm_blocking_params {
+  int64_t m_par;  // rows per OpenMP chunk (multiple of block_size_m)
+  int64_t n_par;  // cols per OpenMP chunk (multiple of block_size_n)
+  int64_t k_blk;  // K panel per brgemm call (multiple of TILE_K)
+};
+
+// Match oneDNN L2_threshold(): use ~75% of a 2 MiB per-core L2.
+inline int64_t gemm_l2_budget_bytes() {
+  return (2048 * 1024 * 3) / 4;
+}
+
+// Upper bound for stack-resident {M_tile x k_blk} temporaries.
+inline int64_t gemm_max_k_blk() {
+  return 4096;
+}
+
+// Pick k_blk so one brgemm's A-panel + B-panel fits in L2.
+//   panel_bytes ~= elem_bytes * (m_tile + n_tile) * k_blk
+inline int64_t compute_k_blk(int64_t m_tile, int64_t n_tile, int64_t elem_bytes = 2) {
+  const int64_t budget = gemm_l2_budget_bytes();
+  const int64_t panel_factor = elem_bytes * (m_tile + n_tile);
+  int64_t k_blk = budget / panel_factor;
+  k_blk = (k_blk / TILE_K) * TILE_K;
+  k_blk = std::max<int64_t>(TILE_K, k_blk);
+  k_blk = std::min<int64_t>(k_blk, gemm_max_k_blk());
+  return k_blk;
+}
+
+// Pick coarse parallel tiles. Uses the same sqrt split as parallel_2d(), but
+// on row/column counts instead of 32x32 micro blocks.
+inline gemm_blocking_params compute_gemm_blocking(int64_t M, int64_t N, int64_t K, int64_t elem_bytes = 2) {
+  constexpr int64_t TILE_M = block_size_m();
+  constexpr int64_t TILE_N = block_size_n();
+
+  const int nth = adjust_num_threads(static_cast<int>(div_up(M, TILE_M)));
+
+  // Bias toward M when M >> N (same idea as oneDNN horizontal traversal).
+  const float aspect = float(M) / float(std::max<int64_t>(N, 1));
+  int64_t m_chunks = std::max<int64_t>(1, int64_t(std::ceil(std::sqrt(aspect * nth))));
+  int64_t n_chunks = std::max<int64_t>(1, int64_t(nth / m_chunks));
+
+  int64_t m_par = div_up(M, m_chunks);
+  int64_t n_par = div_up(N, n_chunks);
+  m_par = div_up(m_par, TILE_M) * TILE_M;
+  n_par = div_up(n_par, TILE_N) * TILE_N;
+
+  const int64_t k_blk = compute_k_blk(TILE_M, TILE_N, elem_bytes);
+  (void)K;
+  return {m_par, n_par, k_blk};
+}
+
 // define threshold using brgemm (intel AMX)
 template <typename T>
 inline bool can_use_brgemm(int M);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Draft patch to close the performance gap between `weight_packed_linear` and PyTorch/oneDNN matmul by adding simplified blocking heuristics inspired by oneDNN's AMX matmul path.

### Problem
The previous implementation tiled the output into fixed 32×32 blocks and passed the **entire K dimension** to each `brgemm` call. For large shapes (e.g. M=12090, N=3072, K=14336) this caused:
- ~36K brgemm invocations
- A+B working set ~1.75MB per call, exceeding L2
- Extra FP32→BF16 conversion on every micro-tile

### Approach (simplified oneDNN mirror)

1. **L2-aware `k_blk`** (`compute_k_blk`): choose K panel size so `m_tile × k_blk + n_tile × k_blk` fits in ~75% of 2MB L2
2. **Coarse parallel tiles** (`compute_gemm_blocking`): split M/N at row/column chunk granularity (not 32×32 micro blocks) using the same sqrt thread partition as `parallel_2d`
3. **K-chunk accumulation**: loop `k0 += k_blk`, call `brgemm(..., add_C=!first_k)`, store output only on the last K-chunk
4. **Traversal order**: `K-chunk → N micro-tile → M micro-tile` (horizontal, matches oneDNN)

### Files changed
- `sgl-kernel/csrc/cpu/gemm.h`: blocking params + heuristics helpers
- `sgl-kernel/csrc/cpu/gemm.cpp`: refactor `brgemm` into `compute/store`, rewrite `weight_packed_linear_kernel_impl` (+ fused float path)

### Notes
- This is a **draft** for review/benchmarking; not yet validated on AMX hardware in CI.
- Small-M AVX512 path (M≤4 bf16) unchanged.
- Future work: dynamic `k_blk` stack buffers for float-weight path, optional K-parallel reduction, bandwidth-model tile search.

## Test plan
- [ ] CPU GEMM unit tests: `test/registered/cpu/test_gemm.py`
- [ ] Benchmark vs `torch.matmul` on M=12090, N=3072, K=14336 (AMX host)
- [ ] Verify numerical correctness with/without bias across dims 2–5

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d7b0f7b-28cd-40fa-b41f-9dc15c642c9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d7b0f7b-28cd-40fa-b41f-9dc15c642c9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>










<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28839092381](https://github.com/mingfeima/sglang/actions/runs/28839092381)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28839092276](https://github.com/mingfeima/sglang/actions/runs/28839092276)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->