### PR TITLE
Fix deepseek_v2 import on CPU CI without cutlass

### DIFF
--- a/python/sglang/jit_kernel/dsa/__init__.py
+++ b/python/sglang/jit_kernel/dsa/__init__.py
@@ -1,5 +1,3 @@
-from sglang.srt.utils import is_hip
-
 from .paged_mqa_logits import (
     aiter_paged_mqa_logits,
     cutedsl_paged_mqa_logits,
@@ -7,9 +5,19 @@ from .paged_mqa_logits import (
     deepgemm_paged_mqa_logits_split,
 )
 
-if not is_hip():
-    # Preserve the original eager import behavior on non-ROCm platforms.
-    from .cutedsl_paged_mqa_logits import CuteDSLPagedMQALogitsRunner, pick_dsl_expand
+_LAZY_CUTEDSL_EXPORTS = {
+    "CuteDSLPagedMQALogitsRunner",
+    "pick_dsl_expand",
+}
+
+
+def __getattr__(name: str):
+    if name in _LAZY_CUTEDSL_EXPORTS:
+        from . import cutedsl_paged_mqa_logits as _cutedsl
+
+        return getattr(_cutedsl, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "CuteDSLPagedMQALogitsRunner",

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -64,11 +64,6 @@ global _use_multi_stream
 _is_cuda = is_cuda()
 _is_hip = is_hip()
 _is_npu = is_npu()
-if not _is_hip:
-    # Preserve the original eager import behavior on non-ROCm platforms.
-    from sglang.jit_kernel.dsa import pick_dsl_expand
-else:
-    pick_dsl_expand = None
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 _is_fp8_fnuz = is_fp8_fnuz()
 _is_gfx95_supported = is_gfx95_supported()
@@ -910,7 +905,8 @@ class Indexer(MultiPlatformOp):
             and forward_batch.forward_mode.is_target_verify()
             and next_n >= 2
         ):
-            assert pick_dsl_expand is not None, "Not supported on AMD/ROCm. "
+            from sglang.jit_kernel.dsa.cutedsl_paged_mqa_logits import pick_dsl_expand
+
             dsl_expand_factor, dsl_atom = pick_dsl_expand(
                 next_n,
                 batch_size=B,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Xeon CPU CI (`test_intel_amx_attention_backend_b.py::test_latency_fp8_moe_model`) fails because `deepseek_v2` cannot import on CPU-only environments:

```
Ignore import error when loading sglang.srt.models.deepseek_v2: No module named 'cutlass'
DeepseekV2ForCausalLM has no SGLang implementation, falling back to Transformers implementation.
KeyError: 'sglang'
```

## Root cause

`jit_kernel/dsa/__init__.py` eagerly imported `pick_dsl_expand` / `CuteDSLPagedMQALogitsRunner` from `cutedsl_paged_mqa_logits.py`, which has a top-level `import cutlass`. That ran during `deepseek_v2` module registration (via `dsa_indexer`), even though CuTe DSL is only needed at runtime on CUDA Blackwell paths.

## Fix

- Make `pick_dsl_expand` and `CuteDSLPagedMQALogitsRunner` lazy exports via `__getattr__` in `jit_kernel/dsa/__init__.py`
- Remove module-level `pick_dsl_expand` import from `dsa_indexer.py`; import it only inside the `use_cute_dsl` runtime branch

`cutedsl_paged_mqa_logits()` was already lazy-importing CuTe DSL inside the function body; this aligns the remaining entry points with that pattern.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e66812f-6e94-4e8b-ad29-bcd89a4c91d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e66812f-6e94-4e8b-ad29-bcd89a4c91d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>










<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28998266988](https://github.com/mingfeima/sglang/actions/runs/28998266988)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28998266872](https://github.com/mingfeima/sglang/actions/runs/28998266872)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->