### PR TITLE
Optimize CPU sigmoid/SiLU with AVX512 rcp14 fast paths

### DIFF
--- a/sgl-kernel/csrc/cpu/activation.cpp
+++ b/sgl-kernel/csrc/cpu/activation.cpp
@@ -69,7 +69,6 @@ void fused_sigmoid_mul_kernel_impl(
   using fVec = at::vec::Vectorized<float>;
 
   constexpr int64_t kVecSize = bVec::size();
-  const fVec one = fVec(1.f);
   at::parallel_for(0, num_tokens, 0, [&](int64_t begin, int64_t end) {
     for (int64_t i = begin; i < end; ++i) {
       const scalar_t* __restrict__ i_ptr = input + i * dim;
@@ -86,8 +85,8 @@ void fused_sigmoid_mul_kernel_impl(
         for (; d <= head_dim - kVecSize; d += kVecSize) {
           auto [x_fvec0, x_fvec1] = load_float_vec2(attn_ptr + d);
           auto [g_fvec0, g_fvec1] = load_float_vec2(gate_ptr + d);
-          x_fvec0 = x_fvec0 / (one + g_fvec0.neg().exp_u20());
-          x_fvec1 = x_fvec1 / (one + g_fvec1.neg().exp_u20());
+          x_fvec0 = x_fvec0 * fast_sigmoid(g_fvec0);
+          x_fvec1 = x_fvec1 * fast_sigmoid(g_fvec1);
           convert_from_float_ext<scalar_t>(x_fvec0, x_fvec1).store(out_ptr + d);
         }
 #pragma GCC unroll 4
@@ -121,7 +120,7 @@ at::Tensor silu_and_mul_cpu(at::Tensor& input) {
         num_tokens,
         d,
         [](float x) { return x / (1.f + std::exp(-x)); },
-        [](Vec x) { return x / (Vec(1.f) + x.neg().exp_u20()); });
+        [](Vec x) { return fast_silu(x); });
   });
   return out;
 }

--- a/sgl-kernel/csrc/cpu/gemm.cpp
+++ b/sgl-kernel/csrc/cpu/gemm.cpp
@@ -171,7 +171,6 @@ inline void scalar_sigmoid_and_mul(
   using bVec = at::vec::Vectorized<scalar_t>;
   using fVec = at::vec::Vectorized<float>;
   // scalar sigmoid
-  const fVec one = fVec(1.f);
   fVec X;
   if constexpr (has_bias) {
     assert(bias != nullptr);
@@ -179,7 +178,7 @@ inline void scalar_sigmoid_and_mul(
   } else {
     X = fVec(input[0]);
   }
-  X = one / (one + X.neg().exp_u20());
+  X = fast_sigmoid(X);
 
   // vec mul
   constexpr int kVecSize = bVec::size();

--- a/sgl-kernel/csrc/cpu/mamba/conv.cpp
+++ b/sgl-kernel/csrc/cpu/mamba/conv.cpp
@@ -177,14 +177,13 @@ struct tinygemm_kernel<at::BFloat16, K, BLOCK_N, has_bias, has_silu> {
 
     using fVec = at::vec::Vectorized<float>;
     using bVec = at::vec::Vectorized<at::BFloat16>;
-    const fVec one = fVec(1.f);
     auto storec = [&](auto i, int64_t m) {
       constexpr int col = i;
       fVec x0 = fVec(vc[col * 2 + 0]);
       fVec x1 = fVec(vc[col * 2 + 1]);
       if constexpr (has_silu) {
-        x0 = x0 / (one + x0.neg().exp_u20());
-        x1 = x1 / (one + x1.neg().exp_u20());
+        x0 = fast_silu(x0);
+        x1 = fast_silu(x1);
       }
       bVec out_vec = convert_from_float_ext<at::BFloat16>(x0, x1);
       out_vec.store(C + m * lda + col * 32);

--- a/sgl-kernel/csrc/cpu/mamba/fla.cpp
+++ b/sgl-kernel/csrc/cpu/mamba/fla.cpp
@@ -1282,8 +1282,8 @@ void fused_gdn_gating_kernel_impl(
 
         fVec g0 = neg_one * A_log_vec0.exp_u20() * softplus(a0 + dt_bias_vec0);
         fVec g1 = neg_one * A_log_vec1.exp_u20() * softplus(a1 + dt_bias_vec1);
-        fVec beta0 = one / (one + (neg_one * b0).exp_u20());
-        fVec beta1 = one / (one + (neg_one * b1).exp_u20());
+        fVec beta0 = fast_sigmoid(neg_one * b0);
+        fVec beta1 = fast_sigmoid(neg_one * b1);
 
         g0.store(out + i * num_heads + j);
         g1.store(out + i * num_heads + j + fvec_size);
@@ -1331,8 +1331,8 @@ void fused_gdn_gating_kernel_impl(
 
         fVec g0 = neg_one * A_log_vec0.exp_u20() * softplus(a0 + dt_bias_vec0);
         fVec g1 = neg_one * A_log_vec1.exp_u20() * softplus(a1 + dt_bias_vec1);
-        fVec beta0 = one / (one + (neg_one * b0).exp_u20());
-        fVec beta1 = one / (one + (neg_one * b1).exp_u20());
+        fVec beta0 = fast_sigmoid(neg_one * b0);
+        fVec beta1 = fast_sigmoid(neg_one * b1);
 
         g0.store(out + i * num_heads + j);
         g1.store(out + i * num_heads + j + fvec_size);

--- a/sgl-kernel/csrc/cpu/moe.cpp
+++ b/sgl-kernel/csrc/cpu/moe.cpp
@@ -132,8 +132,6 @@ inline void silu_and_mul(
   using bVec = at::vec::Vectorized<scalar_t>;
   using fVec = at::vec::Vectorized<float>;
 
-  const fVec one = fVec(1.f);
-
   // no remainder
   for (int64_t m = 0; m < m_size; ++m) {
     scalar_t* __restrict__ out = output + m * N;
@@ -145,12 +143,8 @@ inline void silu_and_mul(
       fVec x1 = fVec::loadu(x + d + fVec::size());
       fVec y0 = fVec::loadu(y + d);
       fVec y1 = fVec::loadu(y + d + fVec::size());
-      // silu
-      x0 = x0 / (one + x0.neg().exp_u20());
-      x1 = x1 / (one + x1.neg().exp_u20());
-      // mul
-      x0 = x0 * y0;
-      x1 = x1 * y1;
+      x0 = fast_silu(x0) * y0;
+      x1 = fast_silu(x1) * y1;
       // convert
       bVec out_vec = convert_from_float_ext<scalar_t>(x0, x1);
       out_vec.store(out + d);
@@ -170,39 +164,30 @@ inline void clamp_sigmoid_and_mul(
   using bVec = at::vec::Vectorized<scalar_t>;
   using fVec = at::vec::Vectorized<float>;
 
-  const fVec one = fVec(1.f);
-  const fVec zero = fVec(0.f);
   const fVec limit_v = fVec(limit);
   const fVec nlimit_v = fVec(-limit);
   const fVec alpha_v = fVec(alpha);
+  const fVec one = fVec(1.f);
 
   // no remainder
   for (int64_t m = 0; m < m_size; ++m) {
     scalar_t* __restrict__ out = output + m * N;
     const float* __restrict__ cur_ptr = input0 + m * BLOCK_N;
     for (int64_t d = 0; d < BLOCK_N; d += bVec::size()) {
-      float tmp_glu0[fVec::size()];     // 16
-      float tmp_linear0[fVec::size()];  // 16
+      float tmp_glu0[fVec::size()];
+      float tmp_linear0[fVec::size()];
 
-      // interleaved: x[2i] = glu, x[2i+1] = linear
+#pragma GCC unroll 4
       for (int j = 0; j < fVec::size(); ++j) {
-        // x0 [0,2,..30]
         tmp_glu0[j] = cur_ptr[d + j * 2];
-        // y0 [1,3,...31]
         tmp_linear0[j] = cur_ptr[d + j * 2 + 1];
       }
       fVec x0 = fVec::loadu(tmp_glu0);
       fVec y0 = fVec::loadu(tmp_linear0);
 
-      // clamp
       x0 = at::vec::minimum(x0, limit_v);
       y0 = at::vec::minimum(limit_v, at::vec::maximum(nlimit_v, y0));
-      // x * sigmoid(x * alpha)
-      x0 = x0 / (one + (x0 * alpha_v).neg().exp_u20());
-      // (y + 1) * x
-      y0 = y0 + one;
-      x0 = x0 * y0;
-      // // convert
+      x0 = fast_sigmoid_glu(x0, alpha_v) * (y0 + one);
       convert_from_float_and_store<scalar_t>(out + d / 2 + offset, x0);
     }
   }
@@ -285,22 +270,17 @@ struct tinygemm_kernel_nn2<at::BFloat16, BLOCK_M, BLOCK_N> {
     }
 
     using Vec = at::vec::Vectorized<float>;
-    const Vec one = Vec(1.f);
     auto storec = [&](auto i) {
       constexpr int row = i / COLS;
       constexpr int col = i % COLS;
       // for COLS = 2, 4 use 512bit store
       if constexpr (col % 2 == 0) {
-        Vec x0 = vc0[row * COLS + col + 0];
-        Vec x1 = vc0[row * COLS + col + 1];
-        Vec y0 = vc1[row * COLS + col + 0];
-        Vec y1 = vc1[row * COLS + col + 1];
-        // silu
-        x0 = x0 / (one + x0.neg().exp_u20());
-        x1 = x1 / (one + x1.neg().exp_u20());
-        // mul
-        x0 = x0 * y0;
-        x1 = x1 * y1;
+        __m512 x0 = vc0[row * COLS + col + 0];
+        __m512 x1 = vc0[row * COLS + col + 1];
+        __m512 y0 = vc1[row * COLS + col + 0];
+        __m512 y1 = vc1[row * COLS + col + 1];
+        x0 = _mm512_mul_ps(_mm512_rcp14_silu_ps(x0), y0);
+        x1 = _mm512_mul_ps(_mm512_rcp14_silu_ps(x1), y1);
 
         _mm512_storeu_si512(
             reinterpret_cast<__m512i*>((C + row * ldc + col * 16)),

--- a/sgl-kernel/csrc/cpu/moe.h
+++ b/sgl-kernel/csrc/cpu/moe.h
@@ -152,7 +152,6 @@ inline void silu_and_mul_stub(
     scalar_t* __restrict__ out, const scalar_t* __restrict__ input, const scalar_t* __restrict__ input2, int64_t size) {
   using bVec = at::vec::Vectorized<scalar_t>;
   using fVec = at::vec::Vectorized<float>;
-  const fVec one = fVec(1.f);
 
   // no remainder
 #pragma GCC unroll 4
@@ -163,10 +162,8 @@ inline void silu_and_mul_stub(
     bVec y = bVec::loadu(input2 + d);
     fVec y0, y1;
     std::tie(y0, y1) = at::vec::convert_to_float(y);
-    x0 = x0 / (one + x0.neg().exp_u20());
-    x1 = x1 / (one + x1.neg().exp_u20());
-    x0 = x0 * y0;
-    x1 = x1 * y1;
+    x0 = fast_silu(x0) * y0;
+    x1 = fast_silu(x1) * y1;
     bVec out_vec = convert_from_float_ext<scalar_t>(x0, x1);
     out_vec.store(out + d);
   }
@@ -230,6 +227,40 @@ inline void copy_mul_stub(scalar_t* __restrict__ out, const scalar_t* __restrict
   }
 }
 
+#if defined(CPU_CAPABILITY_AVX512)
+template <>
+inline void clamp_sigmoid_and_mul_stub<at::BFloat16>(
+    at::BFloat16* __restrict__ out,
+    const at::BFloat16* __restrict__ input,
+    int64_t size,
+    const float alpha,
+    const float limit) {
+  const __m512 vlimit = _mm512_set1_ps(limit);
+  const __m512 vnlimit = _mm512_set1_ps(-limit);
+  const __m512 valpha = _mm512_set1_ps(alpha);
+  const __m512 vone = _mm512_set1_ps(1.f);
+
+  auto process = [&](__m512 v) -> __m256i {
+    __m512 glu, lin;
+    _mm512_deinterleave_ps(v, glu, lin);
+    glu = _mm512_min_ps(glu, vlimit);
+    lin = _mm512_min_ps(vlimit, _mm512_max_ps(vnlimit, lin));
+    __m512 result = _mm512_mul_ps(_mm512_rcp14_sigmoid_glu_ps(glu, valpha), _mm512_add_ps(lin, vone));
+    return _mm512_cvtneps_pbh(result);
+  };
+
+#pragma GCC unroll 4
+  for (int64_t d = 0; d < 2 * size; d += 32) {
+    __m512i bx = _mm512_loadu_si512(reinterpret_cast<const __m512i*>(input + d));
+    __m256i o0 = process(CVT_BF16_TO_FP32(_mm512_extracti32x8_epi32(bx, 0)));
+    __m256i o1 = process(CVT_BF16_TO_FP32(_mm512_extracti32x8_epi32(bx, 1)));
+    _mm512_storeu_si512(
+        reinterpret_cast<__m512i*>(out + d / 2),
+        _mm512_inserti32x8(_mm512_castsi256_si512(o0), o1, 1));
+  }
+}
+#endif
+
 template <typename scalar_t>
 inline void clamp_sigmoid_and_mul_stub(
     scalar_t* __restrict__ out,
@@ -240,40 +271,31 @@ inline void clamp_sigmoid_and_mul_stub(
   using bVec = at::vec::Vectorized<scalar_t>;
   using fVec = at::vec::Vectorized<float>;
   const fVec one = fVec(1.f);
-  const fVec zero = fVec(0.f);
   const fVec limit_v = fVec(limit);
   const fVec nlimit_v = fVec(-limit);
   const fVec alpha_v = fVec(alpha);
 
-  // no remainder
 #pragma GCC unroll 4
-  for (int64_t d = 0; d < size; d += bVec::size()) {
+  for (int64_t d = 0; d < 2 * size; d += bVec::size()) {
     bVec x = bVec::loadu(input + d);
     fVec x0_, y0_;
     std::tie(x0_, y0_) = at::vec::convert_to_float(x);
-    float tmp_buffer[fVec::size() * 2];  // 32
-    float tmp_glu[fVec::size()];         // 16
-    float tmp_linear[fVec::size()];      // 16
+    float tmp_buffer[fVec::size() * 2];
+    float tmp_glu[fVec::size()];
+    float tmp_linear[fVec::size()];
     x0_.store(tmp_buffer);
     y0_.store(tmp_buffer + fVec::size());
-    // interleaved: x[2i] = glu, x[2i+1] = linear
+#pragma GCC unroll 4
     for (int j = 0; j < fVec::size(); ++j) {
-      // x0 [0,2,..30]
       tmp_glu[j] = tmp_buffer[j * 2];
-      // y0 [1,3,...31]
       tmp_linear[j] = tmp_buffer[j * 2 + 1];
     }
     fVec x0 = fVec::loadu(tmp_glu);
     fVec y0 = fVec::loadu(tmp_linear);
 
-    // clamp
     x0 = at::vec::minimum(x0, limit_v);
     y0 = at::vec::minimum(limit_v, at::vec::maximum(nlimit_v, y0));
-    // x * sigmoid(x * alpha)
-    x0 = x0 / (one + (x0 * alpha_v).neg().exp_u20());
-    // (y + 1) * x
-    y0 = y0 + one;
-    x0 = x0 * y0;
+    x0 = fast_sigmoid_glu(x0, alpha_v) * (y0 + one);
     convert_from_float_and_store<scalar_t>(out + d / 2, x0);
   }
 }

--- a/sgl-kernel/csrc/cpu/moe_int8.cpp
+++ b/sgl-kernel/csrc/cpu/moe_int8.cpp
@@ -48,14 +48,10 @@ inline void silu_and_mul(
     vc1[col] = _mm512_mul_ps(_mm512_mul_ps(vc1[col], vas), vbs1[col]);
   };
 
-  using bVec = at::vec::Vectorized<scalar_t>;
-  using fVec = at::vec::Vectorized<float>;
-  const fVec one = fVec(1.f);
   auto silu_and_mul = [&](auto col) {
-    fVec x = fVec(vc0[col]);
-    fVec y = fVec(vc1[col]);
-    x = x / (one + x.neg().exp_u20());
-    vc0[col] = x * y;
+    __m512 x = vc0[col];
+    __m512 y = vc1[col];
+    vc0[col] = _mm512_mul_ps(_mm512_rcp14_silu_ps(x), y);
   };
 
   auto storec = [&](auto col, int64_t m) {
@@ -224,23 +220,17 @@ struct tinygemm_kernel_vnni<at::BFloat16, BLOCK_M, BLOCK_N> {
     };
     Unroll<ROWS * COLS>{}(scalec);
 
-    using Vec = at::vec::Vectorized<float>;
-    const Vec one = Vec(1.f);
     auto storec = [&](auto i) {
       constexpr int row = i / COLS;
       constexpr int col = i % COLS;
       // for COLS = 2, 4 use 512bit store
       if constexpr (col % 2 == 0) {
-        Vec x0 = _mm512_castsi512_ps(vc0[row * COLS + col + 0]);
-        Vec x1 = _mm512_castsi512_ps(vc0[row * COLS + col + 1]);
-        Vec y0 = _mm512_castsi512_ps(vc1[row * COLS + col + 0]);
-        Vec y1 = _mm512_castsi512_ps(vc1[row * COLS + col + 1]);
-        // silu
-        x0 = x0 / (one + x0.neg().exp_u20());
-        x1 = x1 / (one + x1.neg().exp_u20());
-        // mul
-        x0 = x0 * y0;
-        x1 = x1 * y1;
+        __m512 x0 = _mm512_castsi512_ps(vc0[row * COLS + col + 0]);
+        __m512 x1 = _mm512_castsi512_ps(vc0[row * COLS + col + 1]);
+        __m512 y0 = _mm512_castsi512_ps(vc1[row * COLS + col + 0]);
+        __m512 y1 = _mm512_castsi512_ps(vc1[row * COLS + col + 1]);
+        x0 = _mm512_mul_ps(_mm512_rcp14_silu_ps(x0), y0);
+        x1 = _mm512_mul_ps(_mm512_rcp14_silu_ps(x1), y1);
 
         _mm512_storeu_si512(
             reinterpret_cast<__m512i*>((C + row * ldc + col * 16)),

--- a/sgl-kernel/csrc/cpu/norm.cpp
+++ b/sgl-kernel/csrc/cpu/norm.cpp
@@ -134,8 +134,7 @@ struct NormTraits<NormMode::RMSNormGated> : NormTraitsBase {
     return x * (gate / (1.f + std::exp(-gate)));
   }
   static inline at::vec::Vectorized<float> apply_gate(at::vec::Vectorized<float> x, at::vec::Vectorized<float> gate) {
-    const auto one = at::vec::Vectorized<float>(1.f);
-    return x * (gate / (one + gate.neg().exp_u20()));
+    return x * gate * fast_sigmoid(gate);
   }
 #if defined(CPU_CAPABILITY_AVX512)
   static inline __m512 apply_gate(__m512 x, __m512 gate) {

--- a/sgl-kernel/csrc/cpu/norm.cpp
+++ b/sgl-kernel/csrc/cpu/norm.cpp
@@ -139,11 +139,7 @@ struct NormTraits<NormMode::RMSNormGated> : NormTraitsBase {
   }
 #if defined(CPU_CAPABILITY_AVX512)
   static inline __m512 apply_gate(__m512 x, __m512 gate) {
-    __m512 minus_gate = _mm512_xor_ps(_mm512_set1_ps(-0.f), gate);
-    __m512 denom = _mm512_add_ps(_mm512_exp_u20_ps(minus_gate), _mm512_set1_ps(1.0f));
-    // NOTE: avoid vdivps -> use reciprocal
-    __m512 sigmoid = _mm512_mul_ps(gate, _mm512_rcp14_ps(denom));
-    return _mm512_mul_ps(x, sigmoid);
+    return _mm512_mul_ps(x, _mm512_mul_ps(gate, _mm512_rcp14_sigmoid_ps(gate)));
   }
 #endif
 };

--- a/sgl-kernel/csrc/cpu/topk.cpp
+++ b/sgl-kernel/csrc/cpu/topk.cpp
@@ -141,16 +141,14 @@ inline void sigmoid(float* __restrict__ out, const scalar_t* __restrict__ input)
   using bVec = at::vec::Vectorized<scalar_t>;
   using fVec = at::vec::Vectorized<float>;
 
-  const fVec one = fVec(1.f);
-
   constexpr int kVecSize = bVec::size();
   for (int d = 0; d < SIZE; d += kVecSize) {
     bVec x_bvec = bVec::loadu(input + d);
     fVec x_fvec0, x_fvec1;
     std::tie(x_fvec0, x_fvec1) = at::vec::convert_to_float(x_bvec);
 
-    x_fvec0 = one / (one + x_fvec0.neg().exp_u20());
-    x_fvec1 = one / (one + x_fvec1.neg().exp_u20());
+    x_fvec0 = fast_sigmoid(x_fvec0);
+    x_fvec1 = fast_sigmoid(x_fvec1);
 
     x_fvec0.store(out + d);
     x_fvec1.store(out + d + fVec::size());
@@ -160,11 +158,10 @@ inline void sigmoid(float* __restrict__ out, const scalar_t* __restrict__ input)
 template <typename scalar_t, int SIZE, std::enable_if_t<std::is_same_v<scalar_t, float>, int> = 0>
 inline void sigmoid(float* __restrict__ out, const float* __restrict__ input) {
   using fVec = at::vec::Vectorized<float>;
-  const fVec one = fVec(1.f);
   constexpr int kVecSize = fVec::size();
   for (int d = 0; d < SIZE; d += kVecSize) {
     fVec in_fvec = fVec::loadu(input + d);
-    in_fvec = one / (one + in_fvec.neg().exp_u20());
+    in_fvec = fast_sigmoid(in_fvec);
     in_fvec.store(out + d);
   }
 }

--- a/sgl-kernel/csrc/cpu/vec.h
+++ b/sgl-kernel/csrc/cpu/vec.h
@@ -557,6 +557,35 @@ inline __attribute__((always_inline)) __m512 _mm512_fexp_u20_ps(const __m512 val
   // final interpretation to float
   return _mm512_castsi512_ps(casted_integer);
 }
+
+// sigmoid(x) = 1 / (1 + exp(-x)); avoid vdivps via rcp14
+inline __attribute__((always_inline)) __m512 _mm512_rcp14_sigmoid_ps(__m512 x) {
+  __m512 minus_x = _mm512_xor_ps(_mm512_set1_ps(-0.f), x);
+  __m512 denom = _mm512_add_ps(_mm512_exp_u20_ps(minus_x), _mm512_set1_ps(1.f));
+  return _mm512_rcp14_ps(denom);
+}
+
+// SiLU(x) = x * sigmoid(x)
+inline __attribute__((always_inline)) __m512 _mm512_rcp14_silu_ps(__m512 x) {
+  return _mm512_mul_ps(x, _mm512_rcp14_sigmoid_ps(x));
+}
 #endif
+
+inline at::vec::Vectorized<float> fast_sigmoid(const at::vec::Vectorized<float>& x) {
+#if defined(CPU_CAPABILITY_AVX512)
+  return at::vec::Vectorized<float>(_mm512_rcp14_sigmoid_ps(x));
+#else
+  const auto one = at::vec::Vectorized<float>(1.f);
+  return one / (one + x.neg().exp_u20());
+#endif
+}
+
+inline at::vec::Vectorized<float> fast_silu(const at::vec::Vectorized<float>& x) {
+#if defined(CPU_CAPABILITY_AVX512)
+  return at::vec::Vectorized<float>(_mm512_rcp14_silu_ps(x));
+#else
+  return x * fast_sigmoid(x);
+#endif
+}
 
 }  // anonymous namespace

--- a/sgl-kernel/csrc/cpu/vec.h
+++ b/sgl-kernel/csrc/cpu/vec.h
@@ -569,6 +569,26 @@ inline __attribute__((always_inline)) __m512 _mm512_rcp14_sigmoid_ps(__m512 x) {
 inline __attribute__((always_inline)) __m512 _mm512_rcp14_silu_ps(__m512 x) {
   return _mm512_mul_ps(x, _mm512_rcp14_sigmoid_ps(x));
 }
+
+// x * sigmoid(x * alpha) for clamped SwiGLU
+inline __attribute__((always_inline)) __m512 _mm512_rcp14_sigmoid_glu_ps(__m512 x, __m512 alpha) {
+  __m512 xa = _mm512_mul_ps(x, alpha);
+  return _mm512_mul_ps(x, _mm512_rcp14_sigmoid_ps(xa));
+}
+
+// deinterleave [a0,b0,a1,b1,...] into even (a*) and odd (b*)
+inline void _mm512_deinterleave_ps(__m512 v, __m512& even, __m512& odd) {
+  __m256 lo = _mm512_castps512_ps256(v);
+  __m256 hi = _mm512_extractf32x8_ps(v, 1);
+  __m256 t0 = _mm256_shuffle_ps(lo, lo, _MM_SHUFFLE(2, 3, 0, 1));
+  __m256 t1 = _mm256_shuffle_ps(hi, hi, _MM_SHUFFLE(2, 3, 0, 1));
+  __m256 g0 = _mm256_shuffle_ps(lo, t0, _MM_SHUFFLE(2, 0, 2, 0));
+  __m256 l0 = _mm256_shuffle_ps(t0, lo, _MM_SHUFFLE(3, 1, 3, 1));
+  __m256 g1 = _mm256_shuffle_ps(hi, t1, _MM_SHUFFLE(2, 0, 2, 0));
+  __m256 l1 = _mm256_shuffle_ps(t1, hi, _MM_SHUFFLE(3, 1, 3, 1));
+  even = _mm512_insertf32x8(_mm512_castps256_ps512(g0), g1, 1);
+  odd = _mm512_insertf32x8(_mm512_castps256_ps512(l0), l1, 1);
+}
 #endif
 
 inline at::vec::Vectorized<float> fast_sigmoid(const at::vec::Vectorized<float>& x) {
@@ -585,6 +605,16 @@ inline at::vec::Vectorized<float> fast_silu(const at::vec::Vectorized<float>& x)
   return at::vec::Vectorized<float>(_mm512_rcp14_silu_ps(x));
 #else
   return x * fast_sigmoid(x);
+#endif
+}
+
+inline at::vec::Vectorized<float> fast_sigmoid_glu(
+    const at::vec::Vectorized<float>& x,
+    const at::vec::Vectorized<float>& alpha) {
+#if defined(CPU_CAPABILITY_AVX512)
+  return at::vec::Vectorized<float>(_mm512_rcp14_sigmoid_glu_ps(x, alpha));
+#else
+  return x * fast_sigmoid(x * alpha);
 #endif
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds merged AVX512 + `at::vec::Vectorized<float>` fast math helpers and applies them across CPU hot paths.

### Primitives (`vec.h`)
- `_mm512_rcp14_sigmoid_ps` / `_mm512_rcp14_silu_ps` / `_mm512_rcp14_sigmoid_glu_ps`
- `_mm512_deinterleave_ps` for interleaved gate/linear layouts
- `fast_sigmoid` / `fast_silu` / `fast_sigmoid_glu` fVec wrappers

### Hot path optimizations
- **`clamp_sigmoid_and_mul_stub`**: AVX512 BF16 fast path (MXFP4 swiglu), `rcp14` + vectorized deinterleave; generic path uses `fast_sigmoid_glu`
- **`silu_and_mul_stub`**, MoE tinygemm (`moe.cpp`, `moe_int8.cpp`), activation, topk, mamba conv/fla, gemm: replace `vdivps` sigmoid with `fast_*` / `_mm512_rcp14_*`

### Bug fix
- `clamp_sigmoid_and_mul_stub` loop bound corrected to `2 * size` (interleaved input is 2× output width)

## Next steps
- Optional Half specialization for `clamp_sigmoid_and_mul_stub`
- Benchmark MXFP4 CPU MoE swiglu path on Sapphire Rapids / Granite Rapids
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eae6f810-2317-47f9-8c88-45ca12247180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eae6f810-2317-47f9-8c88-45ca12247180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>
























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29390969628](https://github.com/mingfeima/sglang/actions/runs/29390969628)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29390969428](https://github.com/mingfeima/sglang/actions/runs/29390969428)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->