### PR TITLE
[CPU] Fix multimodal RoPE GQA input checks

### DIFF
--- a/sgl-kernel/csrc/cpu/rope.cpp
+++ b/sgl-kernel/csrc/cpu/rope.cpp
@@ -385,14 +385,18 @@ std::tuple<at::Tensor, at::Tensor> multimodal_rotary_embedding_cpu(
   TORCH_CHECK(positions.dim() == 1 || positions.dim() == 2, "positions must be a 1D or 2D tensor");
   CHECK_EQ(positions.scalar_type(), at::kLong);
   CHECK_DIM(2, query);
-
-  const auto input_dtype = query.scalar_type();
-  int64_t rotary_dim = cos_sin_cache.size(1);
-  int64_t num_tokens = positions.size(-1);
-
   CHECK_LAST_DIM_CONTIGUOUS_INPUT(query);
-  CHECK_INPUT_SHAPE_DTYPE<true>(key, {num_tokens, query.size(1), head_size}, input_dtype);
-  CHECK_INPUT_SHAPE_DTYPE<false>(cos_sin_cache, {cos_sin_cache.size(0), rotary_dim}, input_dtype);
+  const auto input_dtype = query.scalar_type();
+  const int64_t num_tokens = positions.size(-1);
+  CHECK_EQ(query.size(0), num_tokens);
+  CHECK_DIM(2, key);
+  CHECK_EQ(key.size(0), num_tokens);
+  CHECK_EQ(key.scalar_type(), input_dtype);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(key);
+  CHECK_DIM(2, cos_sin_cache);
+  const int64_t rotary_dim = cos_sin_cache.size(1);
+  CHECK_EQ(cos_sin_cache.scalar_type(), input_dtype);
+  CHECK_INPUT(cos_sin_cache);
 
   const RopeParams p{query, key, head_size, rotary_dim};
   TORCH_CHECK(p.rotary_dim <= p.head_size, "rotary_dim must be <= head_size");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

Rebase onto latest `pr_rope_refactor` (`update mrope`). Multimodal 2D fold/`MropeCosSinRow` is already upstream; this PR keeps the GQA input-check fix for `test_mrope`.

## Modifications

- Fix `multimodal_rotary_embedding_cpu` checks: drop
  `CHECK_INPUT_SHAPE_DTYPE(key, {num_tokens, query.size(1), head_size})`
  (wrong for GQA; caused `expected [512, 2048, 128], got [512, 128]`).
- Use `CHECK_EQ` / `CHECK_LAST_DIM_CONTIGUOUS_INPUT` / `CHECK_INPUT` for key and `cos_sin_cache`.

## Accuracy Tests

- `test/registered/cpu/test_rope.py::test_mrope` (was failing before this fix).

## Checklist

- [ ] Format with pre-commit
- [ ] Re-run `test_mrope` on Xeon / `SGLANG_USE_CPU_ENGINE=1`
- [ ] N/A docs
- [ ] N/A speed benchmarks
- [x] Follow existing CPU rope style

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-060b1032-5064-4e3c-a33d-92aab98a007c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-060b1032-5064-4e3c-a33d-92aab98a007c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29806439419](https://github.com/mingfeima/sglang/actions/runs/29806439419)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #29806439225](https://github.com/mingfeima/sglang/actions/runs/29806439225)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->